### PR TITLE
feat: inicializar PWA de presupuesto local-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# presupuesto
+# PresuPWA
+
+Aplicación PWA mobile-first para gestionar presupuesto personal en Chile. Está construida con React + TypeScript + Vite, TailwindCSS, Dexie (IndexedDB) y funciona completamente offline con sincronización diferida.
+
+## Requisitos
+
+- Node.js 18+
+- npm o pnpm
+
+## Instalación
+
+```bash
+npm install
+npm run dev
+```
+
+La app se sirve en `http://localhost:5173`. Puedes instalarla como PWA desde el navegador y funciona offline gracias al Service Worker cache-first.
+
+## Scripts
+
+- `npm run dev` – entorno de desarrollo Vite.
+- `npm run build` – compila la app y el Service Worker.
+- `npm run preview` – previsualiza el build.
+- `npm run test` – ejecuta pruebas unitarias y de accesibilidad con Vitest y Testing Library.
+
+## Características clave
+
+- Captura rápida de movimientos con numpad, autocompletado de comerciantes y reglas de categorización.
+- Gestión de suscripciones con normalización a valor mensual, recordatorios (stub Web Push) y registro de cobros.
+- Obligaciones indexadas por IPC con cálculo automático del monto ajustado y generación de movimientos.
+- Panel de KPIs con tasa de ahorro, DTI, hormigas y comparativas de gasto.
+- Importación/exportación local-first con File System Access API y fallback `<input type="file">`.
+- Cola de reintentos IndexedDB sin Background Sync y soporte para share target de texto/imágenes.
+- Dark mode por defecto, accesibilidad con roles ARIA, atajos y foco visible.
+
+## Limitaciones iOS
+
+Safari iOS no soporta File System Access API ni Background Sync. La cola de reintentos se limpia al reabrir la app y se recomienda fijar la PWA en pantalla de inicio para un mejor soporte offline.
+
+## Seeds y datos iniciales
+
+Al iniciar por primera vez se insertan movimientos, suscripciones, obligaciones, índices IPC y reglas de comerciantes para explorar todas las vistas.
+
+## Notas sobre PWA
+
+- `manifest.webmanifest` incluye `share_target` y start URL `/capturar`.
+- El Service Worker cachea el app shell y guarda peticiones fallidas en IndexedDB para reintentos posteriores.
+- Las funciones de Web Push y actualización automática de IPC incluyen `// TODO` para integrar APIs reales.
+
+## Testing
+
+Las pruebas cubren helpers de formato, IPC, reglas de hormigas y flujos de accesibilidad básicos en la pantalla de captura rápida.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0f172a" />
+    <title>Presupuesto Personal</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "presupuesto-pwa",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@tanstack/react-virtual": "^3.0.0",
+    "date-fns": "^3.3.1",
+    "dexie": "^3.2.4",
+    "dexie-react-hooks": "^1.1.6",
+    "uuid": "^9.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.10.3",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.4",
+    "vite-plugin-static-copy": "^0.18.1",
+    "vitest": "^1.4.0",
+    "@types/uuid": "^9.0.7"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#0f172a" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="96" fill="#0ea5e9">P</text>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#0f172a" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="280" fill="#0ea5e9">P</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,38 @@
+import { lazy, Suspense } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import LoadingScreen from './components/LoadingScreen';
+import { SeedProvider } from './db/seeds';
+
+const QuickAddPage = lazy(() => import('./pages/capturar/QuickAddPage'));
+const MovimientosPage = lazy(() => import('./pages/movimientos/MovimientosPage'));
+const PanelPage = lazy(() => import('./pages/panel/PanelPage'));
+const SuscripcionesPage = lazy(() => import('./pages/suscripciones/SuscripcionesPage'));
+const ObligacionesPage = lazy(() => import('./pages/obligaciones/ObligacionesPage'));
+const IndicesPage = lazy(() => import('./pages/indices/IndicesPage'));
+const ImportPage = lazy(() => import('./pages/importar/ImportPage'));
+const AjustesPage = lazy(() => import('./pages/ajustes/AjustesPage'));
+
+function App() {
+  return (
+    <SeedProvider>
+      <Suspense fallback={<LoadingScreen />}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<Navigate to="/capturar" replace />} />
+            <Route path="/capturar" element={<QuickAddPage />} />
+            <Route path="/movimientos" element={<MovimientosPage />} />
+            <Route path="/panel" element={<PanelPage />} />
+            <Route path="/suscripciones" element={<SuscripcionesPage />} />
+            <Route path="/obligaciones" element={<ObligacionesPage />} />
+            <Route path="/indices" element={<IndicesPage />} />
+            <Route path="/importar" element={<ImportPage />} />
+            <Route path="/ajustes" element={<AjustesPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
+    </SeedProvider>
+  );
+}
+
+export default App;

--- a/src/__tests__/accessibility.test.tsx
+++ b/src/__tests__/accessibility.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuickAddPage from '@/pages/capturar/QuickAddPage';
+import { budgetDB } from '@/db/dexie';
+
+vi.mock('dexie-react-hooks', () => ({
+  useLiveQuery: () => []
+}));
+
+vi.mock('@/hooks/useOfflineQueue', () => ({
+  useOfflineQueue: () => ({ pendingCount: 0, enqueue: vi.fn() })
+}));
+
+describe('accesibilidad', () => {
+  it('mantiene orden de foco en captura rápida', async () => {
+    const addMock = vi.spyOn(budgetDB.movimientos, 'add').mockResolvedValue(undefined as any);
+    render(<QuickAddPage />);
+    const user = userEvent.setup();
+    const buttons = screen.getAllByRole('tab');
+    expect(buttons[0]).toHaveAccessibleName('Gasto');
+    await user.tab();
+    expect(document.activeElement).toBe(buttons[0]);
+    await user.keyboard('{ArrowRight}');
+    expect(buttons[1]).toHaveAttribute('aria-selected', 'true');
+    addMock.mockRestore();
+  });
+});

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { derivePrecioMesSuscripcion, formatCLP } from '@/lib/format';
+import { Suscripcion } from '@/db/dexie';
+
+describe('format helpers', () => {
+  it('formatea CLP sin decimales', () => {
+    expect(formatCLP(12500)).toBe('CLP\xa012.500');
+  });
+
+  it('calcula precio mensual para anual', () => {
+    const suscripcion = {
+      id: '1',
+      servicio: 'Test',
+      periodicidad: 'Anual',
+      precioCiclo: 120000,
+      categoria: 'Ocio y suscripciones',
+      renuevaEl: new Date().toISOString(),
+      estado: 'Activa',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    } as Suscripcion;
+    expect(derivePrecioMesSuscripcion(suscripcion)).toBe(10000);
+  });
+});

--- a/src/__tests__/ipc.test.ts
+++ b/src/__tests__/ipc.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { calcularAjusteIPC } from '@/lib/ipc';
+
+describe('IPC helpers', () => {
+  it('ajusta monto según índice', () => {
+    expect(calcularAjusteIPC(400000, 100, 110)).toBe(440000);
+  });
+
+  it('usa base si no hay índice actual', () => {
+    expect(calcularAjusteIPC(400000, 100, undefined)).toBe(400000);
+  });
+});

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isHormiga } from '@/lib/rules';
+import { Movimiento } from '@/db/dexie';
+
+describe('rules', () => {
+  it('detecta gasto hormiga por categoría y monto', () => {
+    const movimiento = {
+      id: '1',
+      fecha: new Date().toISOString(),
+      tipo: 'Gasto',
+      categoria: 'Comida fuera',
+      monto: 3000,
+      mes: '2024-01'
+    } as Movimiento;
+    expect(isHormiga(movimiento)).toBe(true);
+  });
+
+  it('ignora gastos altos', () => {
+    const movimiento = {
+      id: '2',
+      fecha: new Date().toISOString(),
+      tipo: 'Gasto',
+      categoria: 'Comida fuera',
+      monto: 12000,
+      mes: '2024-01'
+    } as Movimiento;
+    expect(isHormiga(movimiento)).toBe(false);
+  });
+});

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,85 @@
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { ReactNode, useEffect } from 'react';
+import BottomNav from './navigation/BottomNav';
+import Sidebar from './navigation/Sidebar';
+import FabAdd from './ui/FabAdd';
+
+const navItems = [
+  { to: '/capturar', label: 'Capturar', icon: '📝' },
+  { to: '/movimientos', label: 'Movimientos', icon: '📄' },
+  { to: '/panel', label: 'Panel', icon: '📊' },
+  { to: '/suscripciones', label: 'Suscripciones', icon: '💡' },
+  { to: '/obligaciones', label: 'Obligaciones', icon: '🏠' },
+  { to: '/indices', label: 'Índices IPC', icon: '📈' },
+  { to: '/importar', label: 'Importar', icon: '⬆️' },
+  { to: '/ajustes', label: 'Ajustes', icon: '⚙️' }
+];
+
+function SectionHeader({ children }: { children: ReactNode }) {
+  return (
+    <header className="sticky top-0 z-20 flex items-center justify-between bg-slate-950/80 px-4 py-3 backdrop-blur">
+      <h1 className="text-xl font-semibold text-slate-100" tabIndex={-1}>
+        {children}
+      </h1>
+      <div className="hidden gap-2 md:flex">
+        {navItems.slice(0, 3).map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              `rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                isActive ? 'bg-brand/10 text-brand' : 'text-slate-300 hover:text-brand'
+              }`
+            }
+          >
+            {item.label}
+          </NavLink>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+const Layout = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        navigate('/capturar');
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'm') {
+        event.preventDefault();
+        navigate('/movimientos');
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'p') {
+        event.preventDefault();
+        navigate('/panel');
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [navigate]);
+
+  const currentNav = navItems.find((item) => item.to === location.pathname);
+
+  return (
+    <div className="flex min-h-screen w-full bg-slate-950 text-slate-100">
+      <Sidebar navItems={navItems} />
+      <div className="flex flex-1 flex-col">
+        <SectionHeader>{currentNav?.label ?? 'Presupuesto'}</SectionHeader>
+        <main className="relative flex-1 pb-24 pt-4 md:pb-8">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+      <FabAdd />
+      <BottomNav items={navItems} />
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,10 @@
+const LoadingScreen = () => (
+  <div className="flex h-screen items-center justify-center bg-slate-950 text-slate-100" role="status" aria-live="polite">
+    <div className="flex flex-col items-center gap-4">
+      <div className="h-16 w-16 animate-spin rounded-full border-4 border-brand border-t-transparent" aria-hidden />
+      <p className="text-lg font-medium">Cargando presupuesto…</p>
+    </div>
+  </div>
+);
+
+export default LoadingScreen;

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -1,0 +1,32 @@
+import { NavLink } from 'react-router-dom';
+
+interface BottomNavProps {
+  items: { to: string; label: string; icon: string }[];
+}
+
+const BottomNav = ({ items }: BottomNavProps) => (
+  <nav
+    className="fixed bottom-0 left-0 right-0 z-30 flex justify-around border-t border-slate-800 bg-slate-900/90 py-2 backdrop-blur md:hidden"
+    role="navigation"
+    aria-label="Navegación inferior"
+  >
+    {items.map((item) => (
+      <NavLink
+        key={item.to}
+        to={item.to}
+        className={({ isActive }) =>
+          `flex flex-col items-center gap-1 rounded-full px-3 py-1 text-xs font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+            isActive ? 'text-brand' : 'text-slate-300'
+          }`
+        }
+      >
+        <span aria-hidden className="text-lg">
+          {item.icon}
+        </span>
+        {item.label}
+      </NavLink>
+    ))}
+  </nav>
+);
+
+export default BottomNav;

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -1,0 +1,38 @@
+import { NavLink } from 'react-router-dom';
+
+interface SidebarProps {
+  navItems: { to: string; label: string; icon: string }[];
+}
+
+const Sidebar = ({ navItems }: SidebarProps) => (
+  <aside className="sticky top-0 hidden h-screen w-64 flex-col border-r border-slate-900 bg-slate-950/80 px-4 py-6 backdrop-blur lg:flex">
+    <div className="mb-8 flex items-center gap-3">
+      <span className="text-2xl" role="img" aria-label="alcancía">
+        🐖
+      </span>
+      <div>
+        <p className="text-sm text-slate-400">Tu presupuesto</p>
+        <p className="text-lg font-semibold">PresuPWA</p>
+      </div>
+    </div>
+    <nav className="flex flex-1 flex-col gap-1" aria-label="Principal">
+      {navItems.map((item) => (
+        <NavLink
+          key={item.to}
+          to={item.to}
+          className={({ isActive }) =>
+            `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+              isActive ? 'bg-brand/10 text-brand' : 'text-slate-300 hover:bg-slate-900'
+            }`
+          }
+        >
+          <span aria-hidden>{item.icon}</span>
+          {item.label}
+        </NavLink>
+      ))}
+    </nav>
+    <p className="mt-auto text-xs text-slate-500">⌨️ Ctrl/Cmd + K para capturar rápido</p>
+  </aside>
+);
+
+export default Sidebar;

--- a/src/components/ui/BarChart.tsx
+++ b/src/components/ui/BarChart.tsx
@@ -1,0 +1,31 @@
+import {
+  Bar,
+  BarChart as ReBarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { formatCLP } from '@/lib/format';
+
+interface BarChartProps {
+  data: { name: string; value: number }[];
+  color?: string;
+}
+
+const BarChart = ({ data, color = '#0ea5e9' }: BarChartProps) => (
+  <div className="h-64">
+    <ResponsiveContainer>
+      <ReBarChart data={data} barSize={32}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+        <XAxis dataKey="name" stroke="#94a3b8" tick={{ fontSize: 12 }} />
+        <YAxis stroke="#94a3b8" tickFormatter={(value) => formatCLP(value)} tick={{ fontSize: 12 }} />
+        <Tooltip formatter={(value: number) => formatCLP(value)} contentStyle={{ backgroundColor: '#0f172a', borderRadius: 12 }} />
+        <Bar dataKey="value" fill={color} radius={[12, 12, 12, 12]} />
+      </ReBarChart>
+    </ResponsiveContainer>
+  </div>
+);
+
+export default BarChart;

--- a/src/components/ui/CategoryChips.tsx
+++ b/src/components/ui/CategoryChips.tsx
@@ -1,0 +1,29 @@
+interface CategoryChipsProps {
+  categories: string[];
+  value?: string;
+  onSelect: (category: string) => void;
+}
+
+const CategoryChips = ({ categories, value, onSelect }: CategoryChipsProps) => (
+  <div className="flex flex-wrap gap-2" role="group" aria-label="Categorías">
+    {categories.map((category) => {
+      const active = category === value;
+      return (
+        <button
+          key={category}
+          type="button"
+          onClick={() => onSelect(category)}
+          className={`rounded-full border px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand ${
+            active
+              ? 'border-brand bg-brand/20 text-brand'
+              : 'border-slate-800 bg-slate-900 text-slate-300 hover:border-brand/60'
+          }`}
+        >
+          {category}
+        </button>
+      );
+    })}
+  </div>
+);
+
+export default CategoryChips;

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,42 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { ReactNode } from 'react';
+
+interface ConfirmDialogProps {
+  title: string;
+  description: string;
+  trigger: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+}
+
+const ConfirmDialog = ({ title, description, trigger, confirmLabel = 'Confirmar', cancelLabel = 'Cancelar', onConfirm }: ConfirmDialogProps) => (
+  <Dialog.Root>
+    <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
+    <Dialog.Portal>
+      <Dialog.Overlay className="fixed inset-0 bg-slate-950/60 backdrop-blur-sm" />
+      <Dialog.Content className="fixed left-1/2 top-1/2 w-[90vw] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-3xl border border-slate-800 bg-slate-900 p-6 text-slate-100 shadow-soft focus:outline-none">
+        <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+        <Dialog.Description className="mt-2 text-sm text-slate-400">{description}</Dialog.Description>
+        <div className="mt-6 flex justify-end gap-3">
+          <Dialog.Close asChild>
+            <button type="button" className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand">
+              {cancelLabel}
+            </button>
+          </Dialog.Close>
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              onClick={onConfirm}
+            >
+              {confirmLabel}
+            </button>
+          </Dialog.Close>
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+export default ConfirmDialog;

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  icon: string;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}
+
+const EmptyState = ({ icon, title, description, action }: EmptyStateProps) => (
+  <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-slate-800 bg-slate-900/60 px-6 py-10 text-center text-slate-300">
+    <span className="text-4xl" aria-hidden>
+      {icon}
+    </span>
+    <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
+    <p className="max-w-md text-sm text-slate-400">{description}</p>
+    {action}
+  </div>
+);
+
+export default EmptyState;

--- a/src/components/ui/FabAdd.tsx
+++ b/src/components/ui/FabAdd.tsx
@@ -1,0 +1,20 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const FabAdd = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isCapture = location.pathname === '/capturar';
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate('/capturar')}
+      className="fixed bottom-20 right-5 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-brand text-3xl text-white shadow-soft transition hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white md:bottom-8"
+      aria-label="Agregar movimiento"
+    >
+      {isCapture ? '✓' : '+'}
+    </button>
+  );
+};
+
+export default FabAdd;

--- a/src/components/ui/KpiCard.tsx
+++ b/src/components/ui/KpiCard.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: ReactNode;
+  trend?: ReactNode;
+  description?: string;
+}
+
+const KpiCard = ({ title, value, trend, description }: KpiCardProps) => (
+  <article className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft" role="group" aria-label={title}>
+    <header className="flex items-center justify-between">
+      <p className="text-sm font-medium text-slate-400">{title}</p>
+      {trend && <span className="text-xs text-brand">{trend}</span>}
+    </header>
+    <p className="mt-3 text-2xl font-semibold text-slate-100">{value}</p>
+    {description && <p className="mt-2 text-xs text-slate-400">{description}</p>}
+  </article>
+);
+
+export default KpiCard;

--- a/src/components/ui/MerchantAutocomplete.tsx
+++ b/src/components/ui/MerchantAutocomplete.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { budgetDB } from '@/db/dexie';
+import { normalizeMerchant } from '@/lib/rules';
+
+interface MerchantAutocompleteProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const MerchantAutocomplete = ({ value, onChange }: MerchantAutocompleteProps) => {
+  const rules = useLiveQuery(() => budgetDB.comercianteReglas.toArray(), []);
+
+  const suggestions = useMemo(() => {
+    if (!rules) return [];
+    const normalized = normalizeMerchant(value);
+    return rules.filter((rule) => normalized.includes(rule.patron));
+  }, [rules, value]);
+
+  return (
+    <div className="space-y-1">
+      <label className="block text-sm font-medium text-slate-300" htmlFor="merchant">
+        Comerciante
+      </label>
+      <input
+        id="merchant"
+        value={value}
+        onChange={(event) => {
+          const next = event.target.value;
+          onChange(next);
+        }}
+        autoComplete="off"
+        className="w-full rounded-2xl border border-slate-800 bg-slate-900 px-4 py-3 text-lg text-slate-100 placeholder-slate-500 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+        placeholder="Starbucks, feria, etc."
+      />
+      {suggestions.length > 0 && (
+        <ul className="flex flex-wrap gap-2" role="listbox">
+          {suggestions.map((rule) => (
+            <li key={rule.id} className="rounded-full bg-slate-800 px-3 py-1 text-xs text-slate-200">
+              {rule.patron}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default MerchantAutocomplete;

--- a/src/components/ui/MonthPicker.tsx
+++ b/src/components/ui/MonthPicker.tsx
@@ -1,0 +1,21 @@
+interface MonthPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const MonthPicker = ({ value, onChange }: MonthPickerProps) => (
+  <div className="space-y-1">
+    <label htmlFor="month-picker" className="block text-sm font-medium text-slate-300">
+      Mes
+    </label>
+    <input
+      id="month-picker"
+      type="month"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+    />
+  </div>
+);
+
+export default MonthPicker;

--- a/src/components/ui/Numpad.tsx
+++ b/src/components/ui/Numpad.tsx
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+
+interface NumpadProps {
+  onInput: (value: string) => void;
+  onBackspace: () => void;
+  onSubmit: () => void;
+}
+
+const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '00', '0', '⌫'];
+
+const Numpad = ({ onInput, onBackspace, onSubmit }: NumpadProps) => {
+  const handleClick = useCallback(
+    (key: string) => {
+      if (key === '⌫') {
+        onBackspace();
+      } else {
+        onInput(key);
+      }
+    },
+    [onBackspace, onInput]
+  );
+
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {keys.map((key) => (
+        <button
+          key={key}
+          type="button"
+          className="rounded-2xl bg-slate-900 py-5 text-2xl font-semibold text-slate-100 shadow-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+          onClick={() => handleClick(key)}
+        >
+          {key}
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onSubmit}
+        className="col-span-3 rounded-2xl bg-brand py-4 text-lg font-semibold text-white shadow-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        Guardar
+      </button>
+    </div>
+  );
+};
+
+export default Numpad;

--- a/src/components/ui/StackedBarChart.tsx
+++ b/src/components/ui/StackedBarChart.tsx
@@ -1,0 +1,36 @@
+import {
+  Bar,
+  BarChart as ReBarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { formatCLP } from '@/lib/format';
+
+interface StackedBarChartProps {
+  data: Record<string, string | number>[];
+  stackKeys: string[];
+  colors: string[];
+}
+
+const StackedBarChart = ({ data, stackKeys, colors }: StackedBarChartProps) => (
+  <div className="h-72">
+    <ResponsiveContainer>
+      <ReBarChart data={data} barGap={4}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+        <XAxis dataKey="name" stroke="#94a3b8" tick={{ fontSize: 12 }} />
+        <YAxis stroke="#94a3b8" tickFormatter={(value) => formatCLP(Number(value))} tick={{ fontSize: 12 }} />
+        <Tooltip formatter={(value: number) => formatCLP(value)} contentStyle={{ backgroundColor: '#0f172a', borderRadius: 12 }} />
+        <Legend wrapperStyle={{ color: '#e2e8f0' }} />
+        {stackKeys.map((key, index) => (
+          <Bar key={key} dataKey={key} stackId="stack" fill={colors[index] ?? colors[0]} radius={[12, 12, 12, 12]} />
+        ))}
+      </ReBarChart>
+    </ResponsiveContainer>
+  </div>
+);
+
+export default StackedBarChart;

--- a/src/db/dexie.ts
+++ b/src/db/dexie.ts
@@ -1,0 +1,119 @@
+import Dexie, { Table } from 'dexie';
+
+export type MovimientoTipo = 'Gasto' | 'Ingreso' | 'Transferencia';
+export type MovimientoCanal =
+  | 'Feria'
+  | 'Supermercado'
+  | 'Cafetería'
+  | 'Restaurant'
+  | 'Delivery'
+  | 'Online'
+  | 'Tienda';
+export type MovimientoContexto = 'Casa' | 'Trabajo' | 'Calle' | 'Viaje';
+export type MovimientoMetodo = 'Débito' | 'Crédito' | 'Efectivo' | 'Transferencia';
+
+export interface Movimiento {
+  id: string;
+  fecha: string;
+  tipo: MovimientoTipo;
+  categoria: string;
+  subcategoria?: string;
+  comerciante?: string;
+  canal?: MovimientoCanal;
+  contexto?: MovimientoContexto;
+  metodo?: MovimientoMetodo;
+  monto: number;
+  esFijo?: boolean;
+  mes: string;
+  suscripcionId?: string;
+  obligacionId?: string;
+}
+
+export type SuscripcionPeriodicidad = 'Mensual' | 'Anual';
+export type SuscripcionCategoria = 'Ocio y suscripciones' | 'Trabajo/Freelance' | 'Educación y libros';
+export type SuscripcionEstado = 'Activa' | 'Trial' | 'Pausada' | 'Cancelar';
+export type SuscripcionUso = 'Alto' | 'Medio' | 'Bajo';
+
+export interface Suscripcion {
+  id: string;
+  servicio: string;
+  periodicidad: SuscripcionPeriodicidad;
+  precioCiclo: number;
+  categoria: SuscripcionCategoria;
+  metodoPago?: string;
+  renuevaEl: string;
+  estado: SuscripcionEstado;
+  uso?: SuscripcionUso;
+  ultimoAumento?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Obligacion {
+  id: string;
+  nombre: string;
+  tipo: 'Pensión' | 'Arriendo indexado' | 'Otro';
+  base: number;
+  mesBase: string;
+  indiceBase: number;
+  indiceActual?: number;
+  fechaPago: string;
+  pagado?: boolean;
+  comprobanteUrl?: string;
+}
+
+export interface IndiceIPC {
+  id: string;
+  mes: string;
+  valor: number;
+  esUltimo?: boolean;
+}
+
+export interface SinkingFund {
+  id: string;
+  nombre: string;
+  montoAnual: number;
+  activo: boolean;
+  mesesMeta?: number;
+}
+
+export interface ComercianteRegla {
+  id: string;
+  patron: string;
+  categoriaPorDefecto?: string;
+  subcategoriaPorDefecto?: string;
+  canalPorDefecto?: string;
+}
+
+export interface OfflineQueueItem {
+  id?: number;
+  type: 'movimiento' | 'suscripcion' | 'obligacion';
+  payload: unknown;
+  status: 'pending' | 'synced';
+  createdAt: number;
+}
+
+export class BudgetDB extends Dexie {
+  movimientos!: Table<Movimiento>;
+  suscripciones!: Table<Suscripcion>;
+  obligaciones!: Table<Obligacion>;
+  indices!: Table<IndiceIPC>;
+  sinkingFunds!: Table<SinkingFund>;
+  comercianteReglas!: Table<ComercianteRegla>;
+  offlineQueue!: Table<OfflineQueueItem>;
+
+  constructor() {
+    super('budget-db');
+    this.version(1).stores({
+      movimientos: 'id, fecha, mes, comerciante, categoria, suscripcionId, obligacionId',
+      suscripciones: 'id, servicio, renuevaEl, categoria',
+      obligaciones: 'id, nombre, tipo, fechaPago',
+      indices: 'id, mes, esUltimo',
+      sinkingFunds: 'id, nombre, activo',
+      comercianteReglas: 'id, patron',
+      offlineQueue: '++id, type, status'
+    });
+  }
+}
+
+export const budgetDB = new BudgetDB();

--- a/src/db/seeds.tsx
+++ b/src/db/seeds.tsx
@@ -1,0 +1,243 @@
+import { createContext, ReactNode, useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import { budgetDB, ComercianteRegla, IndiceIPC, Movimiento, Obligacion, SinkingFund, Suscripcion } from './dexie';
+import LoadingScreen from '@/components/LoadingScreen';
+
+interface SeedContextValue {
+  ready: boolean;
+}
+
+export const SeedContext = createContext<SeedContextValue>({ ready: false });
+
+const movimientosSeed: Movimiento[] = [
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Comida fuera',
+    subcategoria: 'Café',
+    comerciante: 'Starbucks',
+    canal: 'Cafetería',
+    contexto: 'Trabajo',
+    metodo: 'Débito',
+    monto: 4500,
+    esFijo: false,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Supermercado',
+    comerciante: 'Lider',
+    canal: 'Supermercado',
+    contexto: 'Casa',
+    metodo: 'Débito',
+    monto: 35000,
+    esFijo: true,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Transporte',
+    comerciante: 'Metro',
+    canal: 'Tienda',
+    contexto: 'Trabajo',
+    metodo: 'Débito',
+    monto: 1200,
+    mes: new Date().toISOString().slice(0, 7)
+  } as Movimiento,
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Ingreso',
+    categoria: 'Sueldo',
+    comerciante: 'Empresa',
+    metodo: 'Transferencia',
+    monto: 1500000,
+    esFijo: true,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Ocio y suscripciones',
+    comerciante: 'Netflix',
+    canal: 'Online',
+    metodo: 'Crédito',
+    monto: 9900,
+    esFijo: true,
+    mes: new Date().toISOString().slice(0, 7),
+    suscripcionId: 'netflix'
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Arriendo',
+    comerciante: 'Pensión Maxi',
+    canal: 'Online',
+    metodo: 'Transferencia',
+    monto: 420000,
+    esFijo: true,
+    mes: new Date().toISOString().slice(0, 7),
+    obligacionId: 'pension-maxi'
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Almuerzo oficina',
+    comerciante: 'Cafetería local',
+    canal: 'Cafetería',
+    contexto: 'Trabajo',
+    metodo: 'Efectivo',
+    monto: 6500,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Comida fuera',
+    comerciante: 'Juanito Sanguches',
+    canal: 'Restaurant',
+    metodo: 'Débito',
+    monto: 7800,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Delivery',
+    comerciante: 'PedidosYa',
+    canal: 'Delivery',
+    metodo: 'Crédito',
+    monto: 12990,
+    mes: new Date().toISOString().slice(0, 7)
+  },
+  {
+    id: uuid(),
+    fecha: new Date().toISOString(),
+    tipo: 'Gasto',
+    categoria: 'Pago tarjeta',
+    comerciante: 'Banco',
+    canal: 'Online',
+    metodo: 'Transferencia',
+    monto: 250000,
+    mes: new Date().toISOString().slice(0, 7)
+  }
+];
+
+const suscripcionesSeed: Suscripcion[] = [
+  {
+    id: 'netflix',
+    servicio: 'Netflix',
+    periodicidad: 'Anual',
+    precioCiclo: 120000,
+    categoria: 'Ocio y suscripciones',
+    metodoPago: 'Crédito',
+    renuevaEl: new Date().toISOString(),
+    estado: 'Activa',
+    uso: 'Alto',
+    ultimoAumento: 12,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  },
+  {
+    id: 'spotify',
+    servicio: 'Spotify',
+    periodicidad: 'Mensual',
+    precioCiclo: 4990,
+    categoria: 'Ocio y suscripciones',
+    metodoPago: 'Débito',
+    renuevaEl: new Date().toISOString(),
+    estado: 'Activa',
+    uso: 'Alto',
+    ultimoAumento: 5,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  },
+  {
+    id: 'notion',
+    servicio: 'Notion Plus',
+    periodicidad: 'Mensual',
+    precioCiclo: 9500,
+    categoria: 'Trabajo/Freelance',
+    metodoPago: 'Crédito',
+    renuevaEl: new Date().toISOString(),
+    estado: 'Trial',
+    uso: 'Medio',
+    ultimoAumento: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+];
+
+const obligacionesSeed: Obligacion[] = [
+  {
+    id: 'pension-maxi',
+    nombre: 'Pensión Maxi',
+    tipo: 'Pensión',
+    base: 400000,
+    mesBase: '2023-12',
+    indiceBase: 110.2,
+    indiceActual: 112.5,
+    fechaPago: new Date().toISOString(),
+    pagado: false
+  }
+];
+
+const indicesSeed: IndiceIPC[] = [
+  { id: 'ipc-2023-12', mes: '2023-12', valor: 110.2 },
+  { id: 'ipc-2024-01', mes: '2024-01', valor: 111.1 },
+  { id: 'ipc-2024-02', mes: '2024-02', valor: 112.5, esUltimo: true },
+  { id: 'ipc-2024-03', mes: '2024-03', valor: 113.0 }
+];
+
+const sinkingSeed: SinkingFund[] = [
+  { id: uuid(), nombre: 'Navidad', montoAnual: 240000, activo: true },
+  { id: uuid(), nombre: 'Vacaciones', montoAnual: 600000, activo: true },
+  { id: uuid(), nombre: 'Mantención auto', montoAnual: 360000, activo: true }
+];
+
+const comerciantesSeed: ComercianteRegla[] = [
+  { id: uuid(), patron: 'starbucks', categoriaPorDefecto: 'Comida fuera', canalPorDefecto: 'Cafetería' },
+  { id: uuid(), patron: 'lider', categoriaPorDefecto: 'Supermercado', canalPorDefecto: 'Supermercado' },
+  { id: uuid(), patron: 'metro', categoriaPorDefecto: 'Transporte', canalPorDefecto: 'Tienda' }
+];
+
+export const SeedProvider = ({ children }: { children: ReactNode }) => {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const seed = async () => {
+      const count = await budgetDB.movimientos.count();
+      if (count === 0) {
+        await budgetDB.transaction('rw', budgetDB.tables, async () => {
+          await budgetDB.movimientos.bulkAdd(movimientosSeed);
+          await budgetDB.suscripciones.bulkAdd(suscripcionesSeed);
+          await budgetDB.obligaciones.bulkAdd(obligacionesSeed);
+          await budgetDB.indices.bulkAdd(indicesSeed);
+          await budgetDB.sinkingFunds.bulkAdd(sinkingSeed);
+          await budgetDB.comercianteReglas.bulkAdd(comerciantesSeed);
+        });
+      }
+      setReady(true);
+    };
+    seed().catch((error) => {
+      console.error('Error al cargar semillas', error);
+      setReady(true);
+    });
+  }, []);
+
+  if (!ready) {
+    return <LoadingScreen />;
+  }
+
+  return <SeedContext.Provider value={{ ready }}>{children}</SeedContext.Provider>;
+};

--- a/src/hooks/useCurrencyCLP.ts
+++ b/src/hooks/useCurrencyCLP.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+
+export const useCurrencyCLP = () => {
+  return useMemo(
+    () =>
+      new Intl.NumberFormat('es-CL', {
+        style: 'currency',
+        currency: 'CLP',
+        maximumFractionDigits: 0
+      }),
+    []
+  );
+};
+
+export const formatCurrencyCLP = (value: number) =>
+  new Intl.NumberFormat('es-CL', {
+    style: 'currency',
+    currency: 'CLP',
+    maximumFractionDigits: 0
+  }).format(value);

--- a/src/hooks/useMonth.ts
+++ b/src/hooks/useMonth.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { formatISO, parseISO } from 'date-fns';
+
+const toMonth = (date: Date) => formatISO(date, { representation: 'date' }).slice(0, 7);
+
+export const useMonth = () => {
+  const [month, setMonth] = useState(() => toMonth(new Date()));
+
+  return {
+    month,
+    setMonth,
+    next: () => {
+      const [year, monthIndex] = month.split('-').map(Number);
+      const nextDate = new Date(year, monthIndex, 1);
+      setMonth(toMonth(nextDate));
+    },
+    prev: () => {
+      const [year, monthIndex] = month.split('-').map(Number);
+      const prevDate = new Date(year, monthIndex - 2, 1);
+      setMonth(toMonth(prevDate));
+    },
+    parse: (value: string) => {
+      try {
+        const parsed = parseISO(`${value}-01`);
+        setMonth(toMonth(parsed));
+      } catch (error) {
+        console.error('Error al parsear mes', error);
+      }
+    }
+  };
+};

--- a/src/hooks/useOfflineQueue.ts
+++ b/src/hooks/useOfflineQueue.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { budgetDB, OfflineQueueItem } from '@/db/dexie';
+
+const flushQueue = async () => {
+  const pending = await budgetDB.offlineQueue.where('status').equals('pending').toArray();
+  for (const item of pending) {
+    // TODO: reemplazar por sincronización real con backend
+    await budgetDB.offlineQueue.update(item.id!, { status: 'synced' });
+  }
+};
+
+export const useOfflineQueue = () => {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    const update = async () => {
+      const count = await budgetDB.offlineQueue.where('status').equals('pending').count();
+      setPendingCount(count);
+    };
+    update().catch(console.error);
+    const listener = () => {
+      update().catch(console.error);
+    };
+    budgetDB.offlineQueue.hook('creating', listener);
+    budgetDB.offlineQueue.hook('updating', listener);
+    return () => {
+      budgetDB.offlineQueue.hook('creating').unsubscribe(listener);
+      budgetDB.offlineQueue.hook('updating').unsubscribe(listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    const sync = () => {
+      if (navigator.serviceWorker?.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'FLUSH_QUEUE' });
+      }
+      flushQueue().catch((error) => console.error('Error al sincronizar cola', error));
+    };
+    window.addEventListener('online', sync);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        sync();
+      }
+    });
+    sync();
+    return () => {
+      window.removeEventListener('online', sync);
+    };
+  }, []);
+
+  const enqueue = async (item: Omit<OfflineQueueItem, 'id' | 'status' | 'createdAt'>) => {
+    await budgetDB.offlineQueue.add({ ...item, status: 'pending', createdAt: Date.now() });
+    setPendingCount((count) => count + 1);
+  };
+
+  return {
+    pendingCount,
+    enqueue
+  };
+};

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,17 @@
+import { Suscripcion } from '@/db/dexie';
+
+export const formatCLP = (value: number) =>
+  new Intl.NumberFormat('es-CL', {
+    style: 'currency',
+    currency: 'CLP',
+    maximumFractionDigits: 0
+  }).format(value);
+
+export const derivePrecioMesSuscripcion = (suscripcion: Suscripcion) => {
+  if (suscripcion.periodicidad === 'Anual') {
+    return Math.round(suscripcion.precioCiclo / 12);
+  }
+  return suscripcion.precioCiclo;
+};
+
+export const aporteMensualSinking = (montoAnual: number) => Math.round(montoAnual / 12);

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,0 +1,16 @@
+import { budgetDB, IndiceIPC } from '@/db/dexie';
+
+export const calcularAjusteIPC = (base: number, indiceBase: number, indiceActual?: number) => {
+  if (!indiceActual) return base;
+  return Math.round(base * (indiceActual / indiceBase));
+};
+
+export const obtenerIndiceActual = async (mes: string): Promise<IndiceIPC | undefined> => {
+  return budgetDB.indices.get({ mes });
+};
+
+export const actualizarIndicesDesdeAPI = async () => {
+  // TODO: conectar con API real (BDE/mindicador) una vez que se cuente con credenciales.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return [] as IndiceIPC[];
+};

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,0 +1,19 @@
+import { Movimiento } from '@/db/dexie';
+
+const hormigaCategorias = ['Comida fuera', 'Ocio y suscripciones'];
+
+export const isHormiga = (movimiento: Movimiento) => {
+  if (movimiento.tipo !== 'Gasto') return false;
+  if (movimiento.monto > 8000) return false;
+  if (movimiento.categoria && hormigaCategorias.includes(movimiento.categoria)) {
+    return true;
+  }
+  return movimiento.canal === 'Cafetería';
+};
+
+export const normalizeMerchant = (value: string) => value.toLowerCase().replace(/\s+/g, '');
+
+export const matchRuleForMerchant = (merchant: string, patrones: string[]) => {
+  const normalized = normalizeMerchant(merchant);
+  return patrones.find((patron) => normalized.includes(patron));
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/tailwind.css';
+import { registerSW } from './pwa/register-sw';
+
+if ('serviceWorker' in navigator) {
+  registerSW();
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/ajustes/AjustesPage.tsx
+++ b/src/pages/ajustes/AjustesPage.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+
+interface Ajustes {
+  caps: {
+    fijos: number;
+    variables: number;
+    sinking: number;
+  };
+  metaAhorro: number;
+  pin?: string;
+}
+
+const defaultAjustes: Ajustes = {
+  caps: {
+    fijos: 600000,
+    variables: 400000,
+    sinking: 150000
+  },
+  metaAhorro: 20,
+  pin: ''
+};
+
+const AjustesPage = () => {
+  const [ajustes, setAjustes] = useState<Ajustes>({ ...defaultAjustes, caps: { ...defaultAjustes.caps } });
+  const [mensaje, setMensaje] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('ajustes');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      setAjustes({ ...defaultAjustes, ...parsed, caps: { ...defaultAjustes.caps, ...parsed.caps } });
+    }
+  }, []);
+
+  const guardar = () => {
+    localStorage.setItem('ajustes', JSON.stringify(ajustes));
+    setMensaje('Ajustes guardados localmente.');
+  };
+
+  const limpiarPIN = () => {
+    setAjustes((prev) => ({ ...prev, pin: '' }));
+    localStorage.removeItem('ajustes-pin');
+  };
+
+  useEffect(() => {
+    if (ajustes.pin) {
+      localStorage.setItem('ajustes-pin', ajustes.pin);
+    }
+  }, [ajustes.pin]);
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Caps mensuales</h2>
+        <label className="text-sm">
+          Fijos
+          <input
+            inputMode="numeric"
+            value={ajustes.caps.fijos}
+            onChange={(event) => setAjustes((prev) => ({ ...prev, caps: { ...prev.caps, fijos: Number(event.target.value) } }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Variables
+          <input
+            inputMode="numeric"
+            value={ajustes.caps.variables}
+            onChange={(event) =>
+              setAjustes((prev) => ({ ...prev, caps: { ...prev.caps, variables: Number(event.target.value) } }))
+            }
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Sinking funds
+          <input
+            inputMode="numeric"
+            value={ajustes.caps.sinking}
+            onChange={(event) => setAjustes((prev) => ({ ...prev, caps: { ...prev.caps, sinking: Number(event.target.value) } }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+      </div>
+
+      <div className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Meta de ahorro</h2>
+        <label className="text-sm">
+          % mensual
+          <input
+            inputMode="numeric"
+            value={ajustes.metaAhorro}
+            onChange={(event) => setAjustes((prev) => ({ ...prev, metaAhorro: Number(event.target.value) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+      </div>
+
+      <div className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Seguridad</h2>
+        <label className="text-sm">
+          PIN local
+          <input
+            inputMode="numeric"
+            value={ajustes.pin}
+            onChange={(event) => setAjustes((prev) => ({ ...prev, pin: event.target.value.slice(0, 6) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={limpiarPIN}
+          className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+        >
+          Limpiar PIN
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={guardar}
+          className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Guardar ajustes
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setAjustes({ ...defaultAjustes, caps: { ...defaultAjustes.caps } });
+            setMensaje('Restauramos valores por defecto.');
+          }}
+          className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+        >
+          Restaurar
+        </button>
+      </div>
+      {mensaje && (
+        <p className="text-xs text-slate-400" role="status" aria-live="polite">
+          {mensaje}
+        </p>
+      )}
+      <p className="text-xs text-slate-500">
+        Las copias locales se guardan en IndexedDB y puedes exportarlas desde Importar.
+      </p>
+    </section>
+  );
+};
+
+export default AjustesPage;

--- a/src/pages/capturar/QuickAddPage.tsx
+++ b/src/pages/capturar/QuickAddPage.tsx
@@ -1,0 +1,217 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { z } from 'zod';
+import { v4 as uuid } from 'uuid';
+import { budgetDB, Movimiento, MovimientoContexto, MovimientoTipo } from '@/db/dexie';
+import Numpad from '@/components/ui/Numpad';
+import MerchantAutocomplete from '@/components/ui/MerchantAutocomplete';
+import CategoryChips from '@/components/ui/CategoryChips';
+import { useOfflineQueue } from '@/hooks/useOfflineQueue';
+import { formatCLP } from '@/lib/format';
+import EmptyState from '@/components/ui/EmptyState';
+
+const movimientoSchema = z.object({
+  monto: z.number().positive(),
+  tipo: z.enum(['Gasto', 'Ingreso', 'Transferencia']),
+  categoria: z.string().min(2),
+  comerciante: z.string().optional(),
+  contexto: z.enum(['Casa', 'Trabajo', 'Calle', 'Viaje']).optional(),
+  esFijo: z.boolean().optional()
+});
+
+const categorias = ['Comida fuera', 'Supermercado', 'Transporte', 'Ocio y suscripciones', 'Arriendo', 'Sueldo'];
+const contextos: MovimientoContexto[] = ['Casa', 'Trabajo', 'Calle', 'Viaje'];
+const tipos: MovimientoTipo[] = ['Gasto', 'Ingreso', 'Transferencia'];
+
+const QuickAddPage = () => {
+  const [monto, setMonto] = useState('0');
+  const [categoria, setCategoria] = useState<string>('Comida fuera');
+  const [tipo, setTipo] = useState<MovimientoTipo>('Gasto');
+  const [comerciante, setComerciante] = useState('');
+  const [contexto, setContexto] = useState<MovimientoContexto>('Trabajo');
+  const [esFijo, setEsFijo] = useState(false);
+  const [mensaje, setMensaje] = useState<string | null>(null);
+  const { enqueue, pendingCount } = useOfflineQueue();
+  const reglas = useLiveQuery(() => budgetDB.comercianteReglas.toArray(), []);
+
+  const montoNumber = useMemo(() => Number(monto.replace(/[^0-9]/g, '')) || 0, [monto]);
+
+  useEffect(() => {
+    const sharedText = new URLSearchParams(window.location.search).get('texto');
+    if (sharedText) {
+      setComerciante(sharedText.slice(0, 80));
+    }
+    if ('launchQueue' in window) {
+      // @ts-expect-error: LaunchQueue no tipado todavía en TS
+      window.launchQueue?.setConsumer?.((launchParams: any) => {
+        if (launchParams.files?.length) {
+          setMensaje('Recibimos archivos compartidos. Agrega notas para guardarlos.');
+        }
+        if (launchParams?.targetURL) {
+          const url = new URL(launchParams.targetURL);
+          const text = url.searchParams.get('texto');
+          if (text) setComerciante(text);
+        }
+      });
+    }
+  }, []);
+
+  const onSubmit = async (event?: FormEvent) => {
+    event?.preventDefault();
+    const payload = {
+      monto: montoNumber,
+      tipo,
+      categoria,
+      comerciante,
+      contexto,
+      esFijo
+    };
+    const validation = movimientoSchema.safeParse(payload);
+    if (!validation.success) {
+      setMensaje('Revisa el monto y la categoría antes de guardar.');
+      return;
+    }
+
+    const now = new Date();
+    const mes = now.toISOString().slice(0, 7);
+    const movimiento: Movimiento = {
+      id: uuid(),
+      fecha: now.toISOString(),
+      tipo,
+      categoria,
+      comerciante,
+      contexto,
+      esFijo,
+      monto: montoNumber,
+      mes
+    };
+
+    try {
+      await budgetDB.movimientos.add(movimiento);
+      await enqueue({ type: 'movimiento', payload: movimiento });
+      setMensaje('Movimiento guardado ✔️');
+      if (!keepData) {
+        setMonto('0');
+        setComerciante('');
+      }
+    } catch (error) {
+      console.error(error);
+      setMensaje('No pudimos guardar ahora. Guardaremos cuando vuelva la conexión.');
+    }
+  };
+
+  const [keepData, setKeepData] = useState(false);
+
+  const handleNumpadInput = (value: string) => {
+    setMonto((prev) => {
+      const digits = prev.replace(/[^0-9]/g, '');
+      const nextDigits = digits === '0' ? value.replace(/^0+/, '') || '0' : digits + value;
+      return formatNumber(nextDigits);
+    });
+  };
+
+  const handleBackspace = () => {
+    setMonto((prev) => {
+      const digits = prev.replace(/[^0-9]/g, '');
+      const next = digits.slice(0, -1) || '0';
+      return formatNumber(next);
+    });
+  };
+
+  const formatNumber = (value: string) => {
+    const number = Number(value);
+    return number === 0 ? '0' : new Intl.NumberFormat('es-CL').format(number);
+  };
+
+  useEffect(() => {
+    if (!comerciante || !reglas) return;
+    const normalized = comerciante.toLowerCase().replace(/\s+/g, '');
+    const match = reglas.find((rule) => normalized.includes(rule.patron));
+    if (match?.categoriaPorDefecto) {
+      setCategoria(match.categoriaPorDefecto);
+    }
+  }, [comerciante, reglas]);
+
+  return (
+    <section className="space-y-6">
+      <form onSubmit={onSubmit} className="space-y-6" aria-label="Agregar movimiento rápido">
+        <div className="flex flex-col gap-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+          <div>
+            <p className="text-sm text-slate-400">Monto</p>
+            <p className="text-4xl font-semibold text-slate-100" aria-live="polite">
+              {formatCLP(montoNumber)}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2" role="tablist" aria-label="Tipo de movimiento">
+            {tipos.map((option) => (
+              <button
+                type="button"
+                key={option}
+                role="tab"
+                aria-selected={tipo === option}
+                onClick={() => setTipo(option)}
+                className={`rounded-full px-4 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                  tipo === option ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <CategoryChips categories={categorias} value={categoria} onSelect={setCategoria} />
+          <MerchantAutocomplete value={comerciante} onChange={setComerciante} />
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Contexto">
+            {contextos.map((item) => (
+              <button
+                type="button"
+                key={item}
+                onClick={() => setContexto(item)}
+                className={`rounded-full px-3 py-1 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                  contexto === item ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+                }`}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <label className="flex items-center gap-3 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={esFijo}
+              onChange={(event) => setEsFijo(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-900"
+            />
+            Es gasto fijo
+          </label>
+          <label className="flex items-center gap-3 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={keepData}
+              onChange={(event) => setKeepData(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-900"
+            />
+            Guardar y repetir (mantiene comerciante y categoría)
+          </label>
+        </div>
+        <Numpad onInput={handleNumpadInput} onBackspace={handleBackspace} onSubmit={onSubmit} />
+        {mensaje && (
+          <p className="rounded-2xl bg-slate-900/70 px-4 py-3 text-sm text-slate-200" role="status" aria-live="polite">
+            {mensaje}
+          </p>
+        )}
+        {pendingCount > 0 && (
+          <p className="text-xs text-slate-400" aria-live="polite">
+            {pendingCount} movimientos esperando sincronización.
+          </p>
+        )}
+      </form>
+      <EmptyState
+        icon="⚡"
+        title="Captura ultra rápida"
+        description="Escribe o comparte desde cualquier app usando el botón compartir y PresuPWA precargará un borrador."
+      />
+    </section>
+  );
+};
+
+export default QuickAddPage;

--- a/src/pages/importar/ImportPage.tsx
+++ b/src/pages/importar/ImportPage.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
+import { budgetDB, Movimiento } from '@/db/dexie';
+import EmptyState from '@/components/ui/EmptyState';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import { normalizeMerchant } from '@/lib/rules';
+
+const movimientoImportSchema = z.object({
+  fecha: z.string(),
+  tipo: z.enum(['Gasto', 'Ingreso', 'Transferencia']).optional(),
+  categoria: z.string().optional(),
+  comerciante: z.string().optional(),
+  monto: z.coerce.number().positive()
+});
+
+const columns = ['fecha', 'tipo', 'categoria', 'comerciante', 'monto'] as const;
+
+type ColumnKey = (typeof columns)[number];
+
+const ImportPage = () => {
+  const reglas = useLiveQuery(() => budgetDB.comercianteReglas.toArray(), []);
+  const [raw, setRaw] = useState<string>('');
+  const [mapping, setMapping] = useState<Record<number, ColumnKey>>({});
+  const [parsed, setParsed] = useState<Movimiento[]>([]);
+  const [mensaje, setMensaje] = useState<string | null>(null);
+
+  const parseCsv = (text: string) => {
+    const lines = text.trim().split(/\r?\n/);
+    const data = lines.map((line) => line.split(',').map((value) => value.trim()));
+    return data;
+  };
+
+  const handleFile = async (file: File) => {
+    const text = await file.text();
+    setRaw(text);
+  };
+
+  const handleFileSystemAccess = async () => {
+    if ('showOpenFilePicker' in window) {
+      // @ts-expect-error: showOpenFilePicker aún no está tipado
+      const [handle] = await window.showOpenFilePicker({ types: [{ accept: { 'text/csv': ['.csv'] } }] });
+      const file = await handle.getFile();
+      handleFile(file);
+    } else {
+      setMensaje('Tu navegador no soporta File System Access. Usa el selector tradicional.');
+    }
+  };
+
+  const aplicarReglas = (movimiento: Movimiento) => {
+    if (!reglas) return movimiento;
+    if (!movimiento.comerciante) return movimiento;
+    const normalized = normalizeMerchant(movimiento.comerciante);
+    const match = reglas.find((rule) => normalized.includes(rule.patron));
+    if (!match) return movimiento;
+    return {
+      ...movimiento,
+      categoria: movimiento.categoria ?? match.categoriaPorDefecto ?? 'Sin categoría'
+    };
+  };
+
+  const preview = () => {
+    const rows = parseCsv(raw);
+    const movimientos: Movimiento[] = [];
+    rows.forEach((row) => {
+      const fechaRaw = row[mappingReverse(mapping, 'fecha')] ?? '';
+      const fecha = parseDate(fechaRaw);
+      if (!fecha) return;
+      const payload: Partial<Movimiento> = {
+        id: uuid(),
+        fecha: fecha.toISOString(),
+        tipo: (row[mappingReverse(mapping, 'tipo')] as Movimiento['tipo']) ?? 'Gasto',
+        categoria: row[mappingReverse(mapping, 'categoria')] ?? 'Sin categoría',
+        comerciante: row[mappingReverse(mapping, 'comerciante')],
+        monto: Number(row[mappingReverse(mapping, 'monto')] ?? 0),
+        mes: fecha.toISOString().slice(0, 7)
+      };
+      const parsed = movimientoImportSchema.safeParse(payload);
+      if (parsed.success) {
+        movimientos.push(aplicarReglas(payload as Movimiento));
+      }
+    });
+    setParsed(movimientos);
+  };
+
+  const commit = async () => {
+    if (parsed.length === 0) {
+      setMensaje('No hay datos para importar.');
+      return;
+    }
+    await budgetDB.transaction('rw', budgetDB.movimientos, async () => {
+      await budgetDB.movimientos.bulkAdd(parsed.map((mov) => ({ ...mov, id: uuid() })));
+    });
+    setMensaje(`Importamos ${parsed.length} movimientos.`);
+  };
+
+  const rows = raw ? parseCsv(raw).slice(0, 5) : [];
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Importar movimientos</h2>
+        <p className="text-sm text-slate-400">
+          Usa File System Access para seleccionar archivos repetidos sin abrir el cuadro de diálogo cada vez.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleFileSystemAccess}
+            className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            Abrir con File System Access
+          </button>
+          <label className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-within:outline focus-within:outline-2 focus-within:outline-brand">
+            <input type="file" accept=".csv" className="sr-only" onChange={(event) => event.target.files?.[0] && handleFile(event.target.files[0])} />
+            Seleccionar CSV
+          </label>
+        </div>
+        {mensaje && (
+          <p className="text-xs text-slate-400" role="status" aria-live="polite">
+            {mensaje}
+          </p>
+        )}
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="space-y-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+          <h2 className="text-sm font-semibold text-slate-200">Mapeo de columnas</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-xs text-slate-300" role="grid">
+              <thead className="text-slate-400">
+                <tr>
+                  {rows[0].map((_, index) => (
+                    <th key={index} className="p-2">
+                      <select
+                        value={mapping[index] ?? ''}
+                        onChange={(event) =>
+                          setMapping((prev) => ({ ...prev, [index]: event.target.value as ColumnKey }))
+                        }
+                        className="rounded-lg border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+                      >
+                        <option value="">Ignorar</option>
+                        {columns.map((column) => (
+                          <option key={column} value={column}>
+                            {column}
+                          </option>
+                        ))}
+                      </select>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, rowIndex) => (
+                  <tr key={rowIndex}>
+                    {row.map((cell, cellIndex) => (
+                      <td key={cellIndex} className="p-2">
+                        {cell}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={preview}
+              className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+            >
+              Previsualizar
+            </button>
+            <ConfirmDialog
+              title="Importar movimientos"
+              description="Aplicaremos reglas de comerciantes y validaremos los datos."
+              onConfirm={commit}
+              trigger={
+                <button
+                  type="button"
+                  className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                >
+                  Importar todo
+                </button>
+              }
+            />
+          </div>
+          {parsed.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold text-slate-300">Previsualización ({parsed.length})</h3>
+              <ul className="space-y-2 text-xs text-slate-300">
+                {parsed.slice(0, 5).map((mov) => (
+                  <li key={mov.id} className="rounded-xl border border-slate-800 bg-slate-900/90 p-2">
+                    {new Date(mov.fecha).toLocaleDateString('es-CL')} · {mov.comerciante} · {mov.categoria} · ${mov.monto}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      ) : (
+        <EmptyState icon="📄" title="Sube un CSV" description="Puedes exportar desde tu banco y mapear columnas para importarlas." />
+      )}
+    </section>
+  );
+};
+
+function mappingReverse(mapping: Record<number, ColumnKey>, column: ColumnKey) {
+  const entry = Object.entries(mapping).find(([, value]) => value === column);
+  return entry ? Number(entry[0]) : -1;
+}
+
+function parseDate(value: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    const parts = value.split('/');
+    if (parts.length === 3) {
+      const [day, month, year] = parts.map(Number);
+      if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
+        return new Date(year < 100 ? 2000 + year : year, month - 1, day);
+      }
+    }
+    return null;
+  }
+  return date;
+}
+
+export default ImportPage;

--- a/src/pages/indices/IndicesPage.tsx
+++ b/src/pages/indices/IndicesPage.tsx
@@ -1,0 +1,134 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
+import { budgetDB, IndiceIPC } from '@/db/dexie';
+import EmptyState from '@/components/ui/EmptyState';
+import { actualizarIndicesDesdeAPI } from '@/lib/ipc';
+
+const schema = z.object({
+  mes: z.string(),
+  valor: z.number().positive(),
+  esUltimo: z.boolean().optional()
+});
+
+const IndicesPage = () => {
+  const indices = useLiveQuery(() => budgetDB.indices.orderBy('mes').reverse().toArray(), []);
+  const [form, setForm] = useState({ mes: new Date().toISOString().slice(0, 7), valor: 100, esUltimo: false });
+  const [mensaje, setMensaje] = useState<string | null>(null);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const parsed = schema.safeParse({ ...form, valor: Number(form.valor) });
+    if (!parsed.success) {
+      setMensaje('Verifica mes y valor.');
+      return;
+    }
+    const indice: IndiceIPC = {
+      id: uuid(),
+      mes: parsed.data.mes,
+      valor: parsed.data.valor,
+      esUltimo: parsed.data.esUltimo
+    };
+    await budgetDB.indices.add(indice);
+    if (indice.esUltimo) {
+      await budgetDB.indices
+        .filter((item) => item.id !== indice.id && item.esUltimo)
+        .modify({ esUltimo: false });
+    }
+    setMensaje('Índice guardado.');
+  };
+
+  const hayDuplicadosUltimo = useMemo(() => {
+    if (!indices) return false;
+    return indices.filter((indice) => indice.esUltimo).length > 1;
+  }, [indices]);
+
+  const actualizarDesdeAPI = async () => {
+    setMensaje('Consultando API…');
+    const nuevos = await actualizarIndicesDesdeAPI();
+    // TODO: reemplazar con carga real desde API externa.
+    if (nuevos.length === 0) {
+      setMensaje('API aún no configurada. Usa carga manual.');
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <form onSubmit={onSubmit} className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Agregar índice IPC</h2>
+        <label className="text-sm">
+          Mes
+          <input
+            type="month"
+            value={form.mes}
+            onChange={(event) => setForm((prev) => ({ ...prev, mes: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Valor
+          <input
+            inputMode="decimal"
+            value={form.valor}
+            onChange={(event) => setForm((prev) => ({ ...prev, valor: Number(event.target.value) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm text-slate-300">
+          <input
+            type="checkbox"
+            checked={form.esUltimo}
+            onChange={(event) => setForm((prev) => ({ ...prev, esUltimo: event.target.checked }))}
+            className="h-4 w-4 rounded border-slate-700 bg-slate-900"
+          />
+          Marcar como último índice publicado
+        </label>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="submit"
+            className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            Guardar índice
+          </button>
+          <button
+            type="button"
+            onClick={actualizarDesdeAPI}
+            className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+          >
+            Actualizar desde API
+          </button>
+        </div>
+        {mensaje && (
+          <p className="text-xs text-slate-400" role="status" aria-live="polite">
+            {mensaje}
+          </p>
+        )}
+        {hayDuplicadosUltimo && (
+          <p className="text-xs text-orange-400">Hay más de un índice marcado como último.</p>
+        )}
+      </form>
+
+      <section className="space-y-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Historial de índices</h2>
+        {!indices || indices.length === 0 ? (
+          <EmptyState icon="📈" title="Sin datos" description="Agrega los índices IPC de tu fuente preferida." />
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {indices.map((indice) => (
+              <li key={indice.id} className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+                <div>
+                  <p className="font-semibold text-slate-100">{indice.mes}</p>
+                  <p className="text-xs text-slate-400">Valor {indice.valor}</p>
+                </div>
+                {indice.esUltimo && <span className="text-xs text-emerald-300">Último publicado</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default IndicesPage;

--- a/src/pages/movimientos/MovimientosPage.tsx
+++ b/src/pages/movimientos/MovimientosPage.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useRef, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { budgetDB, Movimiento } from '@/db/dexie';
+import { formatCLP } from '@/lib/format';
+import { isHormiga } from '@/lib/rules';
+import MonthPicker from '@/components/ui/MonthPicker';
+import EmptyState from '@/components/ui/EmptyState';
+import { useCurrencyCLP } from '@/hooks/useCurrencyCLP';
+
+const quickFilters = [
+  { label: 'Hoy', value: 'today' },
+  { label: 'Esta semana', value: 'week' },
+  { label: 'Mes', value: 'month' }
+] as const;
+
+const MovimientosPage = () => {
+  const movimientos = useLiveQuery(() => budgetDB.movimientos.orderBy('fecha').reverse().toArray(), []);
+  const [mes, setMes] = useState(() => new Date().toISOString().slice(0, 7));
+  const [tipo, setTipo] = useState<'Todos' | Movimiento['tipo']>('Todos');
+  const [categoria, setCategoria] = useState<string>('Todas');
+  const [search, setSearch] = useState('');
+  const [quick, setQuick] = useState<typeof quickFilters[number]['value']>('month');
+  const numberFormat = useCurrencyCLP();
+
+  const filtered = useMemo(() => {
+    if (!movimientos) return [];
+    const now = new Date();
+    return movimientos.filter((mov) => {
+      if (tipo !== 'Todos' && mov.tipo !== tipo) return false;
+      if (categoria !== 'Todas' && mov.categoria !== categoria) return false;
+      if (mov.mes !== mes) return false;
+      if (search && !mov.comerciante?.toLowerCase().includes(search.toLowerCase())) return false;
+      if (quick === 'today') {
+        const today = new Date();
+        const movDate = new Date(mov.fecha);
+        if (movDate.toDateString() !== today.toDateString()) return false;
+      }
+      if (quick === 'week') {
+        const movDate = new Date(mov.fecha);
+        const diff = Math.abs(now.getTime() - movDate.getTime());
+        if (diff > 7 * 24 * 60 * 60 * 1000) return false;
+      }
+      return true;
+    });
+  }, [movimientos, tipo, categoria, mes, search, quick]);
+
+  const categorias = useMemo(() => {
+    return Array.from(new Set(movimientos?.map((mov) => mov.categoria).filter(Boolean))).sort();
+  }, [movimientos]);
+
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 72,
+    overscan: 10
+  });
+
+  const groupedPorComerciante = useMemo(() => {
+    const map = new Map<string, { count: number; total: number }>();
+    filtered.forEach((mov) => {
+      const key = mov.comerciante ?? 'Sin comerciante';
+      const current = map.get(key) ?? { count: 0, total: 0 };
+      current.count += 1;
+      current.total += mov.monto;
+      map.set(key, current);
+    });
+    return Array.from(map.entries()).map(([comerciante, value]) => ({
+      comerciante,
+      ...value,
+      promedio: value.total / value.count
+    }));
+  }, [filtered]);
+
+  if (!movimientos) {
+    return <p>Cargando movimientos…</p>;
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <MonthPicker value={mes} onChange={setMes} />
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filtros rápidos">
+          {quickFilters.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              onClick={() => setQuick(filter.value)}
+              className={`rounded-full px-3 py-1 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                quick === filter.value ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+              }`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {(['Todos', 'Gasto', 'Ingreso', 'Transferencia'] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setTipo(option)}
+              className={`rounded-full px-3 py-1 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                tipo === option ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setCategoria('Todas')}
+            className={`rounded-full px-3 py-1 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+              categoria === 'Todas' ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+            }`}
+          >
+            Todas
+          </button>
+          {categorias.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => setCategoria(cat)}
+              className={`rounded-full px-3 py-1 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                categoria === cat ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+        <label className="w-full" htmlFor="search">
+          <span className="text-xs text-slate-400">Buscar comerciante</span>
+          <input
+            id="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+            placeholder="Starbucks, feria…"
+          />
+        </label>
+      </div>
+      {filtered.length === 0 ? (
+        <EmptyState icon="🗂" title="Sin movimientos" description="Captura un gasto desde el botón + o importa tu historial." />
+      ) : (
+        <div className="space-y-6">
+          <div ref={parentRef} className="max-h-[420px] overflow-y-auto pr-2">
+            <div
+              style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: 'relative' }}
+              className="space-y-0"
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const movimiento = filtered[virtualRow.index];
+                const top = virtualRow.start;
+                const hormiga = isHormiga(movimiento);
+                return (
+                  <article
+                    key={movimiento.id}
+                    className="absolute left-0 right-0 flex items-center justify-between rounded-2xl border border-slate-900 bg-slate-900/70 px-4 py-3 text-sm text-slate-200 shadow-soft"
+                    style={{ top, transform: 'translateY(0)' }}
+                    role="listitem"
+                  >
+                    <div>
+                      <p className="font-semibold text-slate-100">{movimiento.comerciante ?? movimiento.categoria}</p>
+                      <p className="text-xs text-slate-400">
+                        {new Date(movimiento.fecha).toLocaleDateString('es-CL')} · {movimiento.categoria}
+                      </p>
+                      {hormiga && <span className="mt-1 inline-flex rounded-full bg-orange-500/20 px-2 py-0.5 text-[10px] text-orange-300">Hormiga</span>}
+                    </div>
+                    <div className="text-right">
+                      <p className={`font-semibold ${movimiento.tipo === 'Ingreso' ? 'text-emerald-400' : 'text-slate-100'}`}>
+                        {movimiento.tipo === 'Ingreso' ? '+' : '-'}
+                        {numberFormat.format(movimiento.monto)}
+                      </p>
+                      {movimiento.canal && <p className="text-[10px] text-slate-500">{movimiento.canal}</p>}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+          <section className="rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+            <h2 className="text-sm font-semibold text-slate-200">Comerciantes frecuentes</h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              {groupedPorComerciante.map((item) => (
+                <li key={item.comerciante} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-slate-100">{item.comerciante}</p>
+                    <p className="text-xs text-slate-400">{item.count} movimientos · Ticket promedio {formatCLP(item.promedio)}</p>
+                  </div>
+                  <span className="text-xs text-slate-300">{formatCLP(item.total)}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default MovimientosPage;

--- a/src/pages/obligaciones/ObligacionesPage.tsx
+++ b/src/pages/obligaciones/ObligacionesPage.tsx
@@ -1,0 +1,232 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
+import { budgetDB, Obligacion } from '@/db/dexie';
+import { calcularAjusteIPC } from '@/lib/ipc';
+import { formatCLP } from '@/lib/format';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import EmptyState from '@/components/ui/EmptyState';
+
+const schema = z.object({
+  nombre: z.string().min(2),
+  tipo: z.enum(['Pensión', 'Arriendo indexado', 'Otro']),
+  base: z.number().positive(),
+  mesBase: z.string(),
+  indiceBase: z.number().positive(),
+  fechaPago: z.string()
+});
+
+const ObligacionesPage = () => {
+  const obligaciones = useLiveQuery(() => budgetDB.obligaciones.toArray(), []);
+  const indices = useLiveQuery(() => budgetDB.indices.toArray(), []);
+  const [form, setForm] = useState({
+    nombre: '',
+    tipo: 'Pensión' as const,
+    base: 0,
+    mesBase: new Date().toISOString().slice(0, 7),
+    indiceBase: 100,
+    fechaPago: new Date().toISOString().slice(0, 10)
+  });
+  const [mensaje, setMensaje] = useState<string | null>(null);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload = { ...form, base: Number(form.base), indiceBase: Number(form.indiceBase) };
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      setMensaje('Completa los campos obligatorios.');
+      return;
+    }
+    const obligacion: Obligacion = {
+      id: uuid(),
+      nombre: parsed.data.nombre,
+      tipo: parsed.data.tipo,
+      base: parsed.data.base,
+      mesBase: parsed.data.mesBase,
+      indiceBase: parsed.data.indiceBase,
+      fechaPago: parsed.data.fechaPago,
+      pagado: false
+    };
+    await budgetDB.obligaciones.add(obligacion);
+    setMensaje('Obligación guardada.');
+    setForm((prev) => ({ ...prev, nombre: '', base: 0 }));
+  };
+
+  const pendientes = useMemo(() => {
+    if (!obligaciones) return [];
+    return obligaciones.filter((obl) => !obl.pagado);
+  }, [obligaciones]);
+
+  const historico = useMemo(() => {
+    if (!obligaciones) return [];
+    return obligaciones.filter((obl) => obl.pagado);
+  }, [obligaciones]);
+
+  const generarPago = async (obligacion: Obligacion) => {
+    const mesActual = new Date().toISOString().slice(0, 7);
+    const indiceActual = indices?.find((indice) => indice.mes === mesActual)?.valor ?? obligacion.indiceActual;
+    const monto = calcularAjusteIPC(obligacion.base, obligacion.indiceBase, indiceActual);
+    const now = new Date();
+    await budgetDB.movimientos.add({
+      id: uuid(),
+      fecha: now.toISOString(),
+      tipo: 'Gasto',
+      categoria: obligacion.tipo,
+      comerciante: obligacion.nombre,
+      monto,
+      esFijo: true,
+      mes: now.toISOString().slice(0, 7),
+      obligacionId: obligacion.id
+    });
+    await budgetDB.obligaciones.update(obligacion.id, { pagado: true, indiceActual });
+    setMensaje('Pago generado como movimiento.');
+  };
+
+  const actualizarIndiceActual = async (obligacion: Obligacion) => {
+    const ultimo = indices?.find((indice) => indice.esUltimo) ?? indices?.at(-1);
+    if (!ultimo) return;
+    await budgetDB.obligaciones.update(obligacion.id, { indiceActual: ultimo.valor });
+  };
+
+  return (
+    <section className="space-y-6">
+      <form onSubmit={onSubmit} className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Nueva obligación</h2>
+        <label className="text-sm">
+          Nombre
+          <input
+            value={form.nombre}
+            onChange={(event) => setForm((prev) => ({ ...prev, nombre: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Tipo
+          <select
+            value={form.tipo}
+            onChange={(event) => setForm((prev) => ({ ...prev, tipo: event.target.value as Obligacion['tipo'] }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="Pensión">Pensión</option>
+            <option value="Arriendo indexado">Arriendo indexado</option>
+            <option value="Otro">Otro</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Base (CLP)
+          <input
+            inputMode="numeric"
+            value={form.base}
+            onChange={(event) => setForm((prev) => ({ ...prev, base: Number(event.target.value) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Mes base
+          <input
+            type="month"
+            value={form.mesBase}
+            onChange={(event) => setForm((prev) => ({ ...prev, mesBase: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Índice base
+          <input
+            inputMode="numeric"
+            value={form.indiceBase}
+            onChange={(event) => setForm((prev) => ({ ...prev, indiceBase: Number(event.target.value) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Fecha de pago
+          <input
+            type="date"
+            value={form.fechaPago}
+            onChange={(event) => setForm((prev) => ({ ...prev, fechaPago: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-2 rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Guardar obligación
+        </button>
+        {mensaje && (
+          <p className="text-xs text-slate-400" role="status" aria-live="polite">
+            {mensaje}
+          </p>
+        )}
+      </form>
+
+      <section className="space-y-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Pendientes del mes</h2>
+        {pendientes.length === 0 ? (
+          <EmptyState icon="📥" title="Sin pendientes" description="Ya registraste todos los pagos indexados." />
+        ) : (
+          <ul className="space-y-3 text-sm">
+            {pendientes.map((obl) => {
+              const montoAjustado = calcularAjusteIPC(obl.base, obl.indiceBase, obl.indiceActual);
+              return (
+                <li key={obl.id} className="flex items-center justify-between gap-3 rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+                  <div>
+                    <p className="font-semibold text-slate-100">{obl.nombre}</p>
+                    <p className="text-xs text-slate-400">
+                      {formatCLP(montoAjustado)} · {new Date(obl.fechaPago).toLocaleDateString('es-CL')}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+                      onClick={() => actualizarIndiceActual(obl)}
+                    >
+                      Actualizar IPC
+                    </button>
+                    <ConfirmDialog
+                      title="Generar pago"
+                      description="Crear un movimiento con el monto ajustado"
+                      onConfirm={() => generarPago(obl)}
+                      trigger={
+                        <button
+                          type="button"
+                          className="rounded-full bg-brand px-3 py-1 text-xs font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                        >
+                          Generar pago
+                        </button>
+                      }
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Histórico</h2>
+        {historico.length === 0 ? (
+          <EmptyState icon="📦" title="Aún sin historial" description="Genera pagos para verlos aquí." />
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {historico.map((obl) => (
+              <li key={obl.id} className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+                <div>
+                  <p className="font-semibold text-slate-100">{obl.nombre}</p>
+                  <p className="text-xs text-slate-400">{new Date(obl.fechaPago).toLocaleDateString('es-CL')}</p>
+                </div>
+                <span className="text-xs text-emerald-300">Pagado</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default ObligacionesPage;

--- a/src/pages/panel/PanelPage.tsx
+++ b/src/pages/panel/PanelPage.tsx
@@ -1,0 +1,196 @@
+import { useMemo, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import KpiCard from '@/components/ui/KpiCard';
+import StackedBarChart from '@/components/ui/StackedBarChart';
+import BarChart from '@/components/ui/BarChart';
+import { budgetDB } from '@/db/dexie';
+import { formatCLP, derivePrecioMesSuscripcion, aporteMensualSinking } from '@/lib/format';
+import { calcularAjusteIPC } from '@/lib/ipc';
+import { isHormiga } from '@/lib/rules';
+import MonthPicker from '@/components/ui/MonthPicker';
+import EmptyState from '@/components/ui/EmptyState';
+
+const PanelPage = () => {
+  const movimientos = useLiveQuery(() => budgetDB.movimientos.toArray(), []);
+  const suscripciones = useLiveQuery(() => budgetDB.suscripciones.toArray(), []);
+  const obligaciones = useLiveQuery(() => budgetDB.obligaciones.toArray(), []);
+  const sinkingFunds = useLiveQuery(() => budgetDB.sinkingFunds.toArray(), []);
+  const indices = useLiveQuery(() => budgetDB.indices.toArray(), []);
+  const [mes, setMes] = useState(() => new Date().toISOString().slice(0, 7));
+
+  const data = useMemo(() => {
+    if (!movimientos) return null;
+    const delMes = movimientos.filter((mov) => mov.mes === mes);
+    const ingresos = delMes.filter((mov) => mov.tipo === 'Ingreso').reduce((acc, mov) => acc + mov.monto, 0);
+    const gastos = delMes.filter((mov) => mov.tipo === 'Gasto').reduce((acc, mov) => acc + mov.monto, 0);
+    const fijos = delMes.filter((mov) => mov.esFijo).reduce((acc, mov) => acc + mov.monto, 0);
+    const sinking = (sinkingFunds ?? [])
+      .filter((fund) => fund.activo)
+      .reduce((acc, fund) => acc + aporteMensualSinking(fund.montoAnual), 0);
+    const variables = gastos - fijos;
+    const ahorro = ingresos - gastos - sinking;
+    const tasaAhorro = ingresos === 0 ? 0 : Math.round((ahorro / ingresos) * 100);
+    const caps = { fijos: 600000, variables: 400000, sinking: 150000 };
+    const desviacion = {
+      fijos: fijos - caps.fijos,
+      variables: variables - caps.variables,
+      sinking: sinking - caps.sinking
+    };
+    const pagosDeuda = delMes
+      .filter((mov) => mov.categoria.toLowerCase().includes('pago'))
+      .reduce((acc, mov) => acc + mov.monto, 0);
+    const dti = ingresos === 0 ? 0 : Math.round((pagosDeuda / ingresos) * 100);
+    const comidaFuera = delMes.filter((mov) => mov.categoria === 'Comida fuera').reduce((acc, mov) => acc + mov.monto, 0);
+    const comidaCasa = delMes.filter((mov) => mov.categoria === 'Supermercado').reduce((acc, mov) => acc + mov.monto, 0);
+
+    const hormigas = delMes.filter(isHormiga);
+    const hormigasPorComerciante = hormigas.reduce<Record<string, { count: number; total: number }>>((acc, mov) => {
+      const key = mov.comerciante ?? 'Sin comerciante';
+      const current = acc[key] ?? { count: 0, total: 0 };
+      current.count += 1;
+      current.total += mov.monto;
+      acc[key] = current;
+      return acc;
+    }, {});
+    const hormigasTop = Object.entries(hormigasPorComerciante)
+      .map(([comerciante, value]) => ({ comerciante, ...value, promedio: Math.round(value.total / value.count) }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3);
+
+    const suscripcionesMensual = (suscripciones ?? []).map((sus) => ({
+      ...sus,
+      precioMes: derivePrecioMesSuscripcion(sus)
+    }));
+    const suscripcionesTop = [...suscripcionesMensual].sort((a, b) => b.precioMes - a.precioMes).slice(0, 5);
+    const totalSuscripcionesMes = suscripcionesMensual.reduce((acc, sus) => acc + sus.precioMes, 0);
+
+    const obligacionesMes = (obligaciones ?? []).map((obl) => {
+      const indiceActual = indices?.find((indice) => indice.mes === mes)?.valor ?? obl.indiceActual;
+      const montoAjustado = calcularAjusteIPC(obl.base, obl.indiceBase, indiceActual);
+      return { ...obl, montoAjustado, pagada: obl.pagado };
+    });
+
+    return {
+      delMes,
+      ingresos,
+      gastos,
+      fijos,
+      variables,
+      sinking,
+      ahorro,
+      tasaAhorro,
+      desviacion,
+      dti,
+      comidaFuera,
+      comidaCasa,
+      hormigasTop,
+      suscripcionesTop,
+      totalSuscripcionesMes,
+      obligacionesMes
+    };
+  }, [movimientos, mes, suscripciones, obligaciones, indices, sinkingFunds]);
+
+  if (!data) {
+    return <p>Cargando panel…</p>;
+  }
+
+  return (
+    <section className="space-y-6">
+      <MonthPicker value={mes} onChange={setMes} />
+      <div className="grid gap-4 md:grid-cols-2">
+        <KpiCard title="Tasa de ahorro" value={`${data.tasaAhorro}%`} description={`Ahorro neto ${formatCLP(data.ahorro)}`} />
+        <KpiCard title="DTI mensual" value={`${data.dti}%`} description="Pagos de deuda / ingreso real" />
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+          <h2 className="text-sm font-semibold text-slate-200">Fijos vs Variables vs Sinking</h2>
+          <StackedBarChart
+            data={[
+              {
+                name: mes,
+                Fijos: data.fijos,
+                Variables: data.variables,
+                Sinking: data.sinking
+              }
+            ]}
+            stackKeys={['Fijos', 'Variables', 'Sinking']}
+            colors={['#38bdf8', '#a855f7', '#f97316']}
+          />
+        </div>
+        <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+          <h2 className="text-sm font-semibold text-slate-200">Desvíos vs caps</h2>
+          <BarChart
+            data={[
+              { name: 'Fijos', value: data.desviacion.fijos },
+              { name: 'Variables', value: data.desviacion.variables },
+              { name: 'Sinking', value: data.desviacion.sinking }
+            ]}
+            color="#f87171"
+          />
+        </div>
+        <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+          <h2 className="text-sm font-semibold text-slate-200">Comida fuera vs casa</h2>
+          <BarChart
+            data={[
+              { name: 'Fuera', value: data.comidaFuera },
+              { name: 'Casa', value: data.comidaCasa }
+            ]}
+            color="#34d399"
+          />
+        </div>
+        <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+          <h2 className="text-sm font-semibold text-slate-200">Top hormigas</h2>
+          {data.hormigasTop.length === 0 ? (
+            <EmptyState icon="🐜" title="Sin hormigas" description="Aún no detectamos gastos pequeños en ocio/comida." />
+          ) : (
+            <ul className="mt-3 space-y-3 text-sm">
+              {data.hormigasTop.map((item) => (
+                <li key={item.comerciante} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-slate-100">{item.comerciante}</p>
+                    <p className="text-xs text-slate-400">
+                      {item.count} veces · Promedio {formatCLP(item.promedio)}
+                    </p>
+                  </div>
+                  <span className="text-xs text-slate-300">{formatCLP(item.total)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Suscripciones</h2>
+        <p className="text-xs text-slate-400">Total mensual estimado {formatCLP(data.totalSuscripcionesMes)}</p>
+        <ul className="mt-3 grid gap-3 md:grid-cols-2">
+          {data.suscripcionesTop.map((sus) => (
+            <li key={sus.id} className="rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+              <p className="font-semibold text-slate-100">{sus.servicio}</p>
+              <p className="text-xs text-slate-400">
+                {sus.periodicidad} · {formatCLP(sus.precioMes)} / mes · Uso {sus.uso ?? '—'}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="rounded-3xl border border-slate-900 bg-slate-900/80 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Obligaciones indexadas</h2>
+        <ul className="mt-3 space-y-3">
+          {data.obligacionesMes.map((obl) => (
+            <li key={obl.id} className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-900/90 p-3 text-sm">
+              <div>
+                <p className="font-semibold text-slate-100">{obl.nombre}</p>
+                <p className="text-xs text-slate-400">{formatCLP(obl.montoAjustado)} · Pago {new Date(obl.fechaPago).toLocaleDateString('es-CL')}</p>
+              </div>
+              <span className={`rounded-full px-3 py-1 text-xs ${obl.pagada ? 'bg-emerald-500/20 text-emerald-300' : 'bg-orange-500/20 text-orange-300'}`}>
+                {obl.pagada ? 'Pagada' : 'Pendiente'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default PanelPage;

--- a/src/pages/suscripciones/SuscripcionesPage.tsx
+++ b/src/pages/suscripciones/SuscripcionesPage.tsx
@@ -1,0 +1,271 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { z } from 'zod';
+import { v4 as uuid } from 'uuid';
+import { budgetDB, Suscripcion } from '@/db/dexie';
+import { derivePrecioMesSuscripcion, formatCLP } from '@/lib/format';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import EmptyState from '@/components/ui/EmptyState';
+
+const schema = z.object({
+  servicio: z.string().min(2),
+  periodicidad: z.enum(['Mensual', 'Anual']),
+  precioCiclo: z.number().positive(),
+  categoria: z.enum(['Ocio y suscripciones', 'Trabajo/Freelance', 'Educación y libros']),
+  metodoPago: z.string().optional(),
+  renuevaEl: z.string(),
+  estado: z.enum(['Activa', 'Trial', 'Pausada', 'Cancelar']),
+  uso: z.enum(['Alto', 'Medio', 'Bajo']).optional()
+});
+
+const defaultValues = {
+  servicio: '',
+  periodicidad: 'Mensual' as const,
+  precioCiclo: 0,
+  categoria: 'Ocio y suscripciones' as const,
+  metodoPago: '',
+  renuevaEl: new Date().toISOString().slice(0, 10),
+  estado: 'Activa' as const,
+  uso: 'Alto' as const
+};
+
+const SuscripcionesPage = () => {
+  const suscripciones = useLiveQuery(() => budgetDB.suscripciones.toArray(), []);
+  const [form, setForm] = useState({ ...defaultValues });
+  const [mensaje, setMensaje] = useState<string | null>(null);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload = { ...form, precioCiclo: Number(form.precioCiclo) };
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      setMensaje('Revisa los campos obligatorios.');
+      return;
+    }
+    const now = new Date().toISOString();
+    const suscripcion: Suscripcion = {
+      id: uuid(),
+      servicio: parsed.data.servicio,
+      periodicidad: parsed.data.periodicidad,
+      precioCiclo: parsed.data.precioCiclo,
+      categoria: parsed.data.categoria,
+      metodoPago: parsed.data.metodoPago,
+      renuevaEl: parsed.data.renuevaEl,
+      estado: parsed.data.estado,
+      uso: parsed.data.uso,
+      ultimoAumento: 0,
+      createdAt: now,
+      updatedAt: now
+    };
+    await budgetDB.suscripciones.add(suscripcion);
+    setMensaje('Suscripción guardada.');
+    setForm({ ...defaultValues });
+    // TODO: programar recordatorio Web Push con backend cuando esté disponible.
+  };
+
+  const proximasRenovaciones = useMemo(() => {
+    if (!suscripciones) return [];
+    return [...suscripciones]
+      .sort((a, b) => new Date(a.renuevaEl).getTime() - new Date(b.renuevaEl).getTime())
+      .slice(0, 5);
+  }, [suscripciones]);
+
+  const carasPorMes = useMemo(() => {
+    if (!suscripciones) return [];
+    return [...suscripciones]
+      .map((sus) => ({ ...sus, precioMes: derivePrecioMesSuscripcion(sus) }))
+      .sort((a, b) => b.precioMes - a.precioMes)
+      .slice(0, 5);
+  }, [suscripciones]);
+
+  const registrarCobro = async (sus: Suscripcion) => {
+    const now = new Date();
+    await budgetDB.movimientos.add({
+      id: uuid(),
+      fecha: now.toISOString(),
+      tipo: 'Gasto',
+      categoria: 'Ocio y suscripciones',
+      comerciante: sus.servicio,
+      canal: 'Online',
+      metodo: 'Crédito',
+      monto: derivePrecioMesSuscripcion(sus),
+      esFijo: true,
+      mes: now.toISOString().slice(0, 7),
+      suscripcionId: sus.id
+    });
+    setMensaje('Registro agregado a movimientos.');
+  };
+
+  const marcarEstado = async (sus: Suscripcion, estado: Suscripcion['estado']) => {
+    await budgetDB.suscripciones.update(sus.id, { estado, updatedAt: new Date().toISOString() });
+  };
+
+  return (
+    <section className="space-y-6">
+      <form onSubmit={onSubmit} className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-lg font-semibold text-slate-100">Agregar suscripción</h2>
+        <label className="text-sm">
+          Servicio
+          <input
+            value={form.servicio}
+            onChange={(event) => setForm((prev) => ({ ...prev, servicio: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+            required
+          />
+        </label>
+        <label className="text-sm">
+          Precio ciclo (CLP)
+          <input
+            type="number"
+            inputMode="numeric"
+            value={form.precioCiclo}
+            onChange={(event) => setForm((prev) => ({ ...prev, precioCiclo: Number(event.target.value) }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+            required
+          />
+        </label>
+        <label className="text-sm">
+          Periodicidad
+          <select
+            value={form.periodicidad}
+            onChange={(event) => setForm((prev) => ({ ...prev, periodicidad: event.target.value as Suscripcion['periodicidad'] }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="Mensual">Mensual</option>
+            <option value="Anual">Anual</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Categoría
+          <select
+            value={form.categoria}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, categoria: event.target.value as Suscripcion['categoria'] }))
+            }
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="Ocio y suscripciones">Ocio y suscripciones</option>
+            <option value="Trabajo/Freelance">Trabajo/Freelance</option>
+            <option value="Educación y libros">Educación y libros</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Método de pago
+          <input
+            value={form.metodoPago}
+            onChange={(event) => setForm((prev) => ({ ...prev, metodoPago: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Renueva el
+          <input
+            type="date"
+            value={form.renuevaEl}
+            onChange={(event) => setForm((prev) => ({ ...prev, renuevaEl: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          />
+        </label>
+        <label className="text-sm">
+          Uso
+          <select
+            value={form.uso}
+            onChange={(event) => setForm((prev) => ({ ...prev, uso: event.target.value as Suscripcion['uso'] }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="Alto">Alto</option>
+            <option value="Medio">Medio</option>
+            <option value="Bajo">Bajo</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Estado
+          <select
+            value={form.estado}
+            onChange={(event) => setForm((prev) => ({ ...prev, estado: event.target.value as Suscripcion['estado'] }))}
+            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="Activa">Activa</option>
+            <option value="Trial">Trial</option>
+            <option value="Pausada">Pausada</option>
+            <option value="Cancelar">Cancelar</option>
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="mt-2 rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Guardar suscripción
+        </button>
+        {mensaje && (
+          <p className="text-xs text-slate-400" role="status" aria-live="polite">
+            {mensaje}
+          </p>
+        )}
+      </form>
+
+      <section className="space-y-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Próximas renovaciones</h2>
+        {proximasRenovaciones.length === 0 ? (
+          <EmptyState icon="🗓" title="Sin renovaciones" description="Agrega tus servicios para recibir recordatorios." />
+        ) : (
+          <ul className="space-y-3 text-sm">
+            {proximasRenovaciones.map((sus) => (
+              <li key={sus.id} className="flex items-center justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+                <div>
+                  <p className="font-semibold text-slate-100">{sus.servicio}</p>
+                  <p className="text-xs text-slate-400">
+                    {new Date(sus.renuevaEl).toLocaleDateString('es-CL')} · {sus.periodicidad} · {formatCLP(derivePrecioMesSuscripcion(sus))}/mes
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+                    onClick={() => registrarCobro(sus)}
+                  >
+                    Registrar cobro
+                  </button>
+                  <ConfirmDialog
+                    title="Cancelar suscripción"
+                    description="¿Seguro que quieres marcarla para cancelación?"
+                    onConfirm={() => marcarEstado(sus, 'Cancelar')}
+                    trigger={
+                      <button
+                        type="button"
+                        className="rounded-full border border-red-600/60 px-3 py-1 text-xs text-red-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-400"
+                      >
+                        Cancelar
+                      </button>
+                    }
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+        <h2 className="text-sm font-semibold text-slate-200">Caras por mes</h2>
+        {carasPorMes.length === 0 ? (
+          <EmptyState icon="💸" title="Sin datos" description="Agrega más suscripciones para ver las más costosas." />
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {carasPorMes.map((sus) => (
+              <li key={sus.id} className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
+                <div>
+                  <p className="font-semibold text-slate-100">{sus.servicio}</p>
+                  <p className="text-xs text-slate-400">Uso {sus.uso ?? '—'} · {sus.periodicidad}</p>
+                </div>
+                <span className="text-xs text-slate-300">{formatCLP(derivePrecioMesSuscripcion(sus))}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default SuscripcionesPage;

--- a/src/pwa/manifest.webmanifest
+++ b/src/pwa/manifest.webmanifest
@@ -1,0 +1,36 @@
+{
+  "name": "PresuPWA",
+  "short_name": "PresuPWA",
+  "start_url": "/capturar",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "lang": "es-CL",
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ],
+  "share_target": {
+    "action": "/capturar",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "titulo",
+      "text": "texto",
+      "files": [
+        {
+          "name": "fotos",
+          "accept": ["image/*"]
+        }
+      ]
+    }
+  }
+}

--- a/src/pwa/register-sw.ts
+++ b/src/pwa/register-sw.ts
@@ -1,0 +1,13 @@
+export const registerSW = async () => {
+  try {
+    const registration = await navigator.serviceWorker.register(
+      new URL('./service-worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+    if ('pushManager' in registration) {
+      // TODO: implementar suscripción Web Push (depende de backend y claves VAPID)
+    }
+  } catch (error) {
+    console.error('Error registrando Service Worker', error);
+  }
+};

--- a/src/pwa/service-worker.ts
+++ b/src/pwa/service-worker.ts
@@ -1,0 +1,136 @@
+/// <reference lib="webworker" />
+
+const sw = self as unknown as ServiceWorkerGlobalScope;
+const CACHE_NAME = 'presupuesto-cache-v1';
+const APP_SHELL = ['/', '/index.html', '/manifest.webmanifest'];
+
+const openQueueDB = () =>
+  new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open('budget-db', 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('offlineQueue')) {
+        db.createObjectStore('offlineQueue', { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+
+const queueStore = async (request: Request) => {
+  const clone = request.clone();
+  const body = await clone.json().catch(() => null);
+  if (!body) return;
+  const db = await openQueueDB();
+  const tx = db.transaction('offlineQueue', 'readwrite');
+  tx.objectStore('offlineQueue').add({
+    type: body.type ?? 'movimiento',
+    payload: body,
+    status: 'pending',
+    createdAt: Date.now()
+  });
+  tx.oncomplete = () => db.close();
+  tx.onerror = () => db.close();
+};
+
+sw.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => sw.skipWaiting())
+  );
+});
+
+sw.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+          return Promise.resolve(true);
+        })
+      )
+    )
+  );
+  sw.clients.claim();
+});
+
+sw.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    event.respondWith(
+      fetch(request.clone()).catch(async () => {
+        await queueStore(request.clone());
+        return new Response(JSON.stringify({ queued: true }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 202
+        });
+      })
+    );
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (url.origin === sw.origin) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        const networkFetch = fetch(request)
+          .then((response) => {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+            return response;
+          })
+          .catch(() => cached);
+        return cached || networkFetch;
+      })
+    );
+  }
+});
+
+sw.addEventListener('message', (event) => {
+  if (event.data?.type === 'FLUSH_QUEUE') {
+    openQueueDB()
+      .then((db) => {
+        const tx = db.transaction('offlineQueue', 'readwrite');
+        const store = tx.objectStore('offlineQueue');
+        const request = store.getAll();
+        request.onsuccess = () => {
+          const items = request.result as Array<{ id?: number }>;
+          items.forEach((item) => {
+            if (typeof item.id !== 'number') return;
+            store.put({ ...item, status: 'synced' }, item.id);
+          });
+        };
+        tx.oncomplete = () => db.close();
+      })
+      .catch((error) => console.error('Error al limpiar cola', error));
+  }
+});
+
+sw.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil(
+    sw.clients.matchAll({ type: 'window' }).then((clients) => {
+      const client = clients.find((c) => 'focus' in c);
+      if (client) {
+        return client.focus();
+      }
+      return sw.clients.openWindow('/suscripciones');
+    })
+  );
+});
+
+// @ts-expect-error: push no implementado aún
+sw.addEventListener('push', (event) => {
+  // TODO: manejar mensajes push (requiere backend)
+  const data = event.data?.json() ?? { title: 'Recordatorio de suscripción' };
+  event.waitUntil(
+    sw.registration.showNotification(data.title, {
+      body: data.body ?? 'Revisa tus próximas renovaciones',
+      icon: '/icons/icon-192.png'
+    })
+  );
+});

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 font-sans;
+}
+
+a {
+  @apply text-brand;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  @apply outline-none ring-2 ring-brand;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,23 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Inter"', ...defaultTheme.fontFamily.sans]
+      },
+      colors: {
+        brand: {
+          DEFAULT: '#0ea5e9',
+          dark: '#0284c7'
+        }
+      },
+      boxShadow: {
+        soft: '0 10px 30px -15px rgba(15, 23, 42, 0.5)'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "Node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest", "vite/client", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "src/pwa/service-worker.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'src/pwa/manifest.webmanifest',
+          dest: '.'
+        }
+      ]
+    })
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts']
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html')
+      }
+    }
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- bootstrap Vite + React + TypeScript app with Tailwind, Dexie, Zod and routing for the presupuesto PWA
- implement local-first data layer with seeds, offline queue, service worker, share target and CLP helpers
- build mobile-first UI flows for captura rápida, movimientos, panel KPI, suscripciones, obligaciones, índices, importación y ajustes
- add Recharts visualizations, accessibility tweaks, and Vitest coverage for formato, IPC, reglas y accesibilidad básica

## Testing
- not run (node toolchain no disponible en el entorno)

------
https://chatgpt.com/codex/tasks/task_e_68d97490c630832eaa7034cb979dd93f