### PR TITLE
Configure GitHub Pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0f172a" />
     <title>Presupuesto Personal</title>
   </head>
   <body class="bg-slate-950 text-slate-100">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="%BASE_URL%src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       ]
     })
   ],
+  base: '/presupuesto/',
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src')


### PR DESCRIPTION
## Summary
- configure the Vite base path for GitHub Pages deployments
- update index.html asset links to resolve via %BASE_URL%

## Testing
- `npm run build` *(fails: TypeScript cannot resolve standard libs and project dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97a014658832e964e77070045ac14