### PR TITLE
Configure React Router basename for GitHub Pages

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ if ('serviceWorker' in navigator) {
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- configure the BrowserRouter to reuse Vite's base URL so routes resolve under /presupuesto/

## Testing
- not run (environment-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d994423d8c832ea81be399075afe05