### PR TITLE
Adjust base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
       ]
     })
   ],
-  base: '/presupuesto/',
+  // Necesario para que los assets se sirvan correctamente bajo /presu-pwa/ en GitHub Pages.
+  base: '/presu-pwa/',
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src')


### PR DESCRIPTION
## Summary
- set the Vite base path to `/presu-pwa/` for GitHub Pages deployments
- document the reason for the base path change to ensure assets load correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99bf5b9b4832eb4d45a2ceb68cc17