### PR TITLE
Register service worker from build root

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,65 @@
+const CACHE_VERSION = 'v2025-09-28';
+const CACHE_PREFIX = 'presupuesto-cache-';
+const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
+const BASE_SCOPE = self.registration.scope;
+const BASE_PATH = new URL('./', BASE_SCOPE).pathname;
+
+const PRECACHE_URLS = [
+  new URL('./', BASE_SCOPE).pathname,
+  new URL('./index.html', BASE_SCOPE).pathname,
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+            .map((key) => caches.delete(key))
+        )
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+  const isSameOrigin = requestURL.origin === self.location.origin;
+  const isInScope = requestURL.pathname.startsWith(BASE_PATH);
+
+  if (!isSameOrigin || !isInScope) {
+    return;
+  }
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cachedResponse = await cache.match(event.request);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      try {
+        const networkResponse = await fetch(event.request);
+        if (networkResponse && networkResponse.ok) {
+          cache.put(event.request, networkResponse.clone());
+        }
+        return networkResponse;
+      } catch (error) {
+        return cachedResponse ?? Promise.reject(error);
+      }
+    })
+  );
+});

--- a/src/pwa/register-sw.ts
+++ b/src/pwa/register-sw.ts
@@ -1,8 +1,8 @@
 export const registerSW = async () => {
   try {
     const registration = await navigator.serviceWorker.register(
-      new URL('./service-worker.ts', import.meta.url),
-      { type: 'module' }
+      `${import.meta.env.BASE_URL}sw.js`,
+      { scope: import.meta.env.BASE_URL }
     );
     if ('pushManager' in registration) {
       // TODO: implementar suscripción Web Push (depende de backend y claves VAPID)


### PR DESCRIPTION
## Summary
- register the service worker from the build root using `import.meta.env.BASE_URL` so it aligns with the deployed index scope
- add a versioned `sw.js` in `public/` that precaches scoped assets and handles fetches without relying on absolute paths

## Testing
- npm run build *(fails: TypeScript configuration in repo lacks DOM/WebWorker/lib definitions in this environment, producing duplicate lib conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d99c0804ec832e93316d0aef804a7a