### PR TITLE
Add postbuild script for GitHub Pages routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ La app se sirve en `http://localhost:5173`. Puedes instalarla como PWA desde el 
 
 - `npm run dev` – entorno de desarrollo Vite.
 - `npm run build` – compila la app y el Service Worker.
+- `npm run postbuild` – se ejecuta tras `npm run build` y duplica `dist/index.html` como `dist/404.html`.
 - `npm run preview` – previsualiza el build.
 - `npm run test` – ejecuta pruebas unitarias y de accesibilidad con Vitest y Testing Library.
 
@@ -50,3 +51,7 @@ Al iniciar por primera vez se insertan movimientos, suscripciones, obligaciones,
 ## Testing
 
 Las pruebas cubren helpers de formato, IPC, reglas de hormigas y flujos de accesibilidad básicos en la pantalla de captura rápida.
+
+## Despliegue en GitHub Pages
+
+GitHub Pages utiliza el archivo `404.html` para servir rutas profundas en aplicaciones SPA. El script de postbuild copia el contenido de `dist/index.html` en `dist/404.html` para que cualquier ruta renderice correctamente la aplicación.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- add an npm postbuild script that duplicates `dist/index.html` as `dist/404.html`
- document the GitHub Pages routing fallback for deep SPA routes in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99c125e38832ea19e267d889d4a6c