### PR TITLE
Restaurar navegación por teclado en captura rápida

### DIFF
--- a/src/pages/capturar/QuickAddPage.tsx
+++ b/src/pages/capturar/QuickAddPage.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { z } from 'zod';
 import { v4 as uuid } from 'uuid';
@@ -132,68 +133,95 @@ const QuickAddPage = () => {
     }
   }, [comerciante, reglas]);
 
+  const tipoButtonsRef = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const focusTipoButton = (index: number) => {
+    tipoButtonsRef.current[index]?.focus();
+  };
+
+  const handleTipoKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+
+    event.preventDefault();
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (index + direction + tipos.length) % tipos.length;
+    setTipo(tipos[nextIndex]);
+    focusTipoButton(nextIndex);
+  };
+
   return (
     <section className="space-y-6">
       <form onSubmit={onSubmit} className="space-y-6" aria-label="Agregar movimiento rápido">
-        <div className="flex flex-col gap-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
-          <div>
-            <p className="text-sm text-slate-400">Monto</p>
-            <p className="text-4xl font-semibold text-slate-100" aria-live="polite">
-              {formatCLP(montoNumber)}
-            </p>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:items-start lg:gap-8">
+          <div className="flex flex-col gap-4 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
+            <div>
+              <p className="text-sm text-slate-400">Monto</p>
+              <p className="text-4xl font-semibold text-slate-100" aria-live="polite">
+                {formatCLP(montoNumber)}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2" role="tablist" aria-label="Tipo de movimiento">
+              {tipos.map((option, index) => (
+                <button
+                  type="button"
+                  key={option}
+                  role="tab"
+                  aria-selected={tipo === option}
+                  onClick={() => setTipo(option)}
+                  onKeyDown={(event) => handleTipoKeyDown(event, index)}
+                  tabIndex={tipo === option ? 0 : -1}
+                  ref={(element) => {
+                    tipoButtonsRef.current[index] = element;
+                  }}
+                  className={`rounded-full px-4 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                    tipo === option ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+                  }`}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+            <CategoryChips categories={categorias} value={categoria} onSelect={setCategoria} />
+            <MerchantAutocomplete value={comerciante} onChange={setComerciante} />
+            <div className="flex flex-wrap gap-2" role="group" aria-label="Contexto">
+              {contextos.map((item) => (
+                <button
+                  type="button"
+                  key={item}
+                  onClick={() => setContexto(item)}
+                  className={`rounded-full px-3 py-1 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
+                    contexto === item ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
+                  }`}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+            <label className="flex items-center gap-3 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={esFijo}
+                onChange={(event) => setEsFijo(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-900"
+              />
+              Es gasto fijo
+            </label>
+            <label className="flex items-center gap-3 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={keepData}
+                onChange={(event) => setKeepData(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-900"
+              />
+              Guardar y repetir (mantiene comerciante y categoría)
+            </label>
           </div>
-          <div className="flex flex-wrap gap-2" role="tablist" aria-label="Tipo de movimiento">
-            {tipos.map((option) => (
-              <button
-                type="button"
-                key={option}
-                role="tab"
-                aria-selected={tipo === option}
-                onClick={() => setTipo(option)}
-                className={`rounded-full px-4 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
-                  tipo === option ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
-                }`}
-              >
-                {option}
-              </button>
-            ))}
+          <div className="flex flex-col gap-6 lg:max-w-xs">
+            <Numpad onInput={handleNumpadInput} onBackspace={handleBackspace} onSubmit={onSubmit} />
           </div>
-          <CategoryChips categories={categorias} value={categoria} onSelect={setCategoria} />
-          <MerchantAutocomplete value={comerciante} onChange={setComerciante} />
-          <div className="flex flex-wrap gap-2" role="group" aria-label="Contexto">
-            {contextos.map((item) => (
-              <button
-                type="button"
-                key={item}
-                onClick={() => setContexto(item)}
-                className={`rounded-full px-3 py-1 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${
-                  contexto === item ? 'bg-brand/20 text-brand' : 'bg-slate-900 text-slate-300'
-                }`}
-              >
-                {item}
-              </button>
-            ))}
-          </div>
-          <label className="flex items-center gap-3 text-sm text-slate-300">
-            <input
-              type="checkbox"
-              checked={esFijo}
-              onChange={(event) => setEsFijo(event.target.checked)}
-              className="h-4 w-4 rounded border-slate-600 bg-slate-900"
-            />
-            Es gasto fijo
-          </label>
-          <label className="flex items-center gap-3 text-sm text-slate-300">
-            <input
-              type="checkbox"
-              checked={keepData}
-              onChange={(event) => setKeepData(event.target.checked)}
-              className="h-4 w-4 rounded border-slate-600 bg-slate-900"
-            />
-            Guardar y repetir (mantiene comerciante y categoría)
-          </label>
         </div>
-        <Numpad onInput={handleNumpadInput} onBackspace={handleBackspace} onSubmit={onSubmit} />
         {mensaje && (
           <p className="rounded-2xl bg-slate-900/70 px-4 py-3 text-sm text-slate-200" role="status" aria-live="polite">
             {mensaje}


### PR DESCRIPTION
## Resumen
- restaurar la navegación por teclado en los botones de tipo dentro de la captura rápida
- asegurar el enfoque y aria-selected al movernos con flechas preservando la alineación del nuevo diseño lateral

## Pruebas
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e32db7f340832ea1793d5b90ac692e