### PR TITLE
Auto sync IPC and UTM indices to current date

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ npm run dev
 
 La app se sirve en `http://localhost:5173`. Puedes instalarla como PWA desde el navegador y funciona offline gracias al Service Worker cache-first.
 
+### Credenciales CMF para IPC y UTM
+
+La pantalla de índices puede sincronizar automáticamente los valores de IPC y UTM desde la Comisión para el Mercado Financiero (CMF). Para habilitarla:
+
+1. Solicita una API Key en [api.cmfchile.cl](https://api.cmfchile.cl).
+2. Crea un archivo `.env.local` en la raíz del proyecto con las variables:
+
+   ```bash
+   VITE_CMF_API_KEY="tu_api_key"
+   VITE_CMF_API_SECRET="tu_token"
+   ```
+
+3. Reinicia `npm run dev` para que Vite exponga las variables. Opcionalmente puedes sobreescribir la URL base con `VITE_CMF_API_BASE_URL` si usas un entorno intermedio de la CMF.
+
 ## Scripts
 
 - `npm run dev` – entorno de desarrollo Vite.
@@ -46,7 +60,7 @@ Al iniciar por primera vez se insertan movimientos, suscripciones, obligaciones,
 
 - `manifest.webmanifest` incluye `share_target` con acción `./capturar` (método GET) y start URL `./?source=pwa`.
 - El Service Worker cachea el app shell y guarda peticiones fallidas en IndexedDB para reintentos posteriores.
-- Las funciones de Web Push y actualización automática de IPC incluyen `// TODO` para integrar APIs reales.
+- Las funciones de Web Push incluyen `// TODO` para integrar APIs reales.
 
 ## Testing
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,7 +10,7 @@ const navItems = [
   { to: '/panel', label: 'Panel', icon: '📊' },
   { to: '/suscripciones', label: 'Suscripciones', icon: '💡' },
   { to: '/obligaciones', label: 'Obligaciones', icon: '🏠' },
-  { to: '/indices', label: 'Índices IPC', icon: '📈' },
+  { to: '/indices', label: 'Índices', icon: '📈' },
   { to: '/importar', label: 'Importar', icon: '⬆️' },
   { to: '/ajustes', label: 'Ajustes', icon: '⚙️' }
 ];

--- a/src/db/dexie.ts
+++ b/src/db/dexie.ts
@@ -66,6 +66,7 @@ export interface IndiceIPC {
   id: string;
   mes: string;
   valor: number;
+  utm?: number;
   esUltimo?: boolean;
 }
 

--- a/src/db/seeds.tsx
+++ b/src/db/seeds.tsx
@@ -192,12 +192,38 @@ const obligacionesSeed: Obligacion[] = [
   }
 ];
 
-const indicesSeed: IndiceIPC[] = [
-  { id: 'ipc-2023-12', mes: '2023-12', valor: 110.2 },
-  { id: 'ipc-2024-01', mes: '2024-01', valor: 111.1 },
-  { id: 'ipc-2024-02', mes: '2024-02', valor: 112.5, esUltimo: true },
-  { id: 'ipc-2024-03', mes: '2024-03', valor: 113.0 }
-];
+const generarIndicesSeed = (): IndiceIPC[] => {
+  const cantidadMeses = 12;
+  const fechaReferencia = new Date();
+  fechaReferencia.setDate(1);
+
+  const indices: IndiceIPC[] = [];
+
+  for (let i = cantidadMeses - 1; i >= 0; i -= 1) {
+    const fecha = new Date(fechaReferencia);
+    fecha.setMonth(fechaReferencia.getMonth() - i);
+
+    const year = fecha.getFullYear();
+    const month = (fecha.getMonth() + 1).toString().padStart(2, '0');
+    const mesIso = `${year}-${month}`;
+
+    const progreso = cantidadMeses - 1 - i;
+    const valor = Number((110 + progreso * 0.5).toFixed(1));
+    const utm = Math.round(62000 + progreso * 320);
+
+    indices.push({
+      id: `ipc-${mesIso}`,
+      mes: mesIso,
+      valor,
+      utm,
+      esUltimo: i === 0
+    });
+  }
+
+  return indices;
+};
+
+const indicesSeed: IndiceIPC[] = generarIndicesSeed();
 
 const sinkingSeed: SinkingFund[] = [
   { id: uuid(), nombre: 'Navidad', montoAnual: 240000, activo: true },

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="vite/client" />
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly VITE_CMF_API_KEY?: string;
+    readonly VITE_CMF_API_SECRET?: string;
+    readonly VITE_CMF_API_BASE_URL?: string;
+  }
+}
+
+interface ImportMetaEnv {
+  readonly VITE_CMF_API_KEY?: string;
+  readonly VITE_CMF_API_SECRET?: string;
+  readonly VITE_CMF_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/cmf.ts
+++ b/src/lib/cmf.ts
@@ -1,0 +1,92 @@
+const DEFAULT_BASE_URL = 'https://api.cmfchile.cl/api-sbifv3/recursos_api';
+
+const apiKey = import.meta.env.VITE_CMF_API_KEY;
+const apiSecret = import.meta.env.VITE_CMF_API_SECRET;
+const baseUrl = import.meta.env.VITE_CMF_API_BASE_URL ?? DEFAULT_BASE_URL;
+
+class MissingCredentialsError extends Error {
+  constructor() {
+    super('Debes configurar las credenciales de la API de la CMF (VITE_CMF_API_KEY y VITE_CMF_API_SECRET).');
+    this.name = 'MissingCredentialsError';
+  }
+}
+
+const getAuthParams = () => {
+  if (!apiKey || !apiSecret) {
+    throw new MissingCredentialsError();
+  }
+  const params = new URLSearchParams();
+  params.set('apikey', apiKey);
+  params.set('token', apiSecret);
+  params.set('formato', 'json');
+  return params;
+};
+
+const parseChileanNumber = (value: string | number | undefined): number | undefined => {
+  if (typeof value === 'number') return value;
+  if (!value) return undefined;
+  const sanitized = value
+    .toString()
+    .trim()
+    .replace(/\./g, '')
+    .replace(',', '.');
+  const parsed = Number(sanitized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const requestFromCMF = async (resource: string, path: string) => {
+  const params = getAuthParams();
+  const url = new URL(`${baseUrl.replace(/\/$/, '')}/${resource}/${path.replace(/^\//, '')}`);
+  url.search = params.toString();
+
+  const response = await fetch(url.toString());
+
+  if (response.status === 404) {
+    return undefined;
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `Error al consultar la API de la CMF (${response.status} ${response.statusText}). ${errorText}`.trim()
+    );
+  }
+
+  return response.json() as Promise<Record<string, unknown>>;
+};
+
+export interface SerieDatoCMF {
+  mes: string;
+  valor: number;
+}
+
+const extractSerieDato = (payload: Record<string, unknown> | undefined, clave: string): SerieDatoCMF | undefined => {
+  if (!payload) return undefined;
+  const series =
+    (payload[clave] as Array<Record<string, string>> | undefined) ??
+    (payload[clave.toLowerCase() as keyof typeof payload] as Array<Record<string, string>> | undefined) ??
+    [];
+  if (!Array.isArray(series) || series.length === 0) return undefined;
+  const registro = series[series.length - 1];
+  const fecha = registro?.Fecha ?? registro?.fecha;
+  const valor = parseChileanNumber(registro?.Valor ?? registro?.valor);
+  if (!fecha || typeof fecha !== 'string' || valor === undefined) return undefined;
+  const mes = fecha.slice(0, 7);
+  return { mes, valor };
+};
+
+export const fetchUTMForMonth = async (year: number, month: number): Promise<SerieDatoCMF | undefined> => {
+  const monthString = month.toString().padStart(2, '0');
+  const payload = await requestFromCMF('utm', `periodo/${year}/${monthString}`);
+  return extractSerieDato(payload, 'UTMs');
+};
+
+export const fetchIPCForMonth = async (year: number, month: number): Promise<SerieDatoCMF | undefined> => {
+  const monthString = month.toString().padStart(2, '0');
+  const payload = await requestFromCMF('ipc', `periodo/${year}/${monthString}`);
+  return extractSerieDato(payload, 'IPCs');
+};
+
+export const isMissingCredentialsError = (error: unknown): error is MissingCredentialsError => {
+  return error instanceof MissingCredentialsError;
+};

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,4 +1,6 @@
+import { v4 as uuid } from 'uuid';
 import { budgetDB, IndiceIPC } from '@/db/dexie';
+import { fetchIPCForMonth, fetchUTMForMonth, isMissingCredentialsError } from './cmf';
 
 export const calcularAjusteIPC = (base: number, indiceBase: number, indiceActual?: number) => {
   if (!indiceActual) return base;
@@ -9,8 +11,144 @@ export const obtenerIndiceActual = async (mes: string): Promise<IndiceIPC | unde
   return budgetDB.indices.get({ mes });
 };
 
-export const actualizarIndicesDesdeAPI = async () => {
-  // TODO: conectar con API real (BDE/mindicador) una vez que se cuente con credenciales.
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  return [] as IndiceIPC[];
+interface MesConsulta {
+  iso: string;
+  year: number;
+  month: number;
+}
+
+const MESES_A_DESCARGAR = 12;
+
+const obtenerMesesRecientes = (cantidad: number): MesConsulta[] => {
+  const meses: MesConsulta[] = [];
+  const fecha = new Date();
+  fecha.setDate(1);
+
+  for (let i = 0; i < cantidad; i += 1) {
+    const year = fecha.getFullYear();
+    const month = fecha.getMonth() + 1;
+    const iso = `${year}-${month.toString().padStart(2, '0')}`;
+    meses.push({ iso, year, month });
+    fecha.setMonth(fecha.getMonth() - 1);
+  }
+
+  return meses;
+};
+
+export interface ActualizacionIndicesResultado {
+  procesados: number;
+  agregados: number;
+  actualizados: number;
+}
+
+const formatearError = (mensaje: string, error: unknown) => {
+  const detalle = error instanceof Error ? error.message : String(error);
+  return `${mensaje}: ${detalle}`;
+};
+
+export const actualizarIndicesDesdeAPI = async (): Promise<ActualizacionIndicesResultado> => {
+  const meses = obtenerMesesRecientes(MESES_A_DESCARGAR);
+  const datosPorMes = new Map<string, { valor?: number; utm?: number }>();
+
+  for (const mes of meses) {
+    try {
+      const ipcDato = await fetchIPCForMonth(mes.year, mes.month);
+      if (ipcDato) {
+        const entry = datosPorMes.get(ipcDato.mes) ?? {};
+        entry.valor = ipcDato.valor;
+        datosPorMes.set(ipcDato.mes, entry);
+      }
+    } catch (error) {
+      if (isMissingCredentialsError(error)) {
+        throw error;
+      }
+      throw new Error(formatearError(`No se pudo obtener el IPC de ${mes.iso}`, error));
+    }
+
+    try {
+      const utmDato = await fetchUTMForMonth(mes.year, mes.month);
+      if (utmDato) {
+        const entry = datosPorMes.get(utmDato.mes) ?? {};
+        entry.utm = utmDato.valor;
+        datosPorMes.set(utmDato.mes, entry);
+      }
+    } catch (error) {
+      if (isMissingCredentialsError(error)) {
+        throw error;
+      }
+      throw new Error(formatearError(`No se pudo obtener la UTM de ${mes.iso}`, error));
+    }
+  }
+
+  if (datosPorMes.size === 0) {
+    return { procesados: 0, agregados: 0, actualizados: 0 };
+  }
+
+  let agregados = 0;
+  let actualizados = 0;
+  let ultimoMesConDato: string | undefined;
+
+  const entradasOrdenadas = Array.from(datosPorMes.entries()).sort(([mesA], [mesB]) => {
+    if (mesA < mesB) return -1;
+    if (mesA > mesB) return 1;
+    return 0;
+  });
+
+  await budgetDB.transaction('rw', budgetDB.indices, async () => {
+    for (const [mes, valores] of entradasOrdenadas) {
+      if (valores.valor === undefined && valores.utm === undefined) {
+        continue;
+      }
+
+      if (!ultimoMesConDato || mes > ultimoMesConDato) {
+        ultimoMesConDato = mes;
+      }
+
+      const existente = await budgetDB.indices.get({ mes });
+
+      if (!existente) {
+        if (valores.valor === undefined) {
+          // No generamos un registro nuevo si la API no entrega valor IPC aún.
+          continue;
+        }
+        const nuevo: IndiceIPC = {
+          id: uuid(),
+          mes,
+          valor: valores.valor,
+          utm: valores.utm
+        };
+        await budgetDB.indices.add(nuevo);
+        agregados += 1;
+        continue;
+      }
+
+      const cambios: Partial<IndiceIPC> = {};
+      let hayCambios = false;
+
+      if (valores.valor !== undefined && valores.valor !== existente.valor) {
+        cambios.valor = valores.valor;
+        hayCambios = true;
+      }
+
+      if (valores.utm !== undefined && valores.utm !== existente.utm) {
+        cambios.utm = valores.utm;
+        hayCambios = true;
+      }
+
+      if (hayCambios) {
+        await budgetDB.indices.update(existente.id, cambios);
+        actualizados += 1;
+      }
+    }
+
+    if (ultimoMesConDato) {
+      const ultimoRegistro = await budgetDB.indices.where('mes').equals(ultimoMesConDato).first();
+      if (ultimoRegistro) {
+        await budgetDB.indices.where('esUltimo').equals(1).modify({ esUltimo: false });
+        await budgetDB.indices.update(ultimoRegistro.id, { esUltimo: true });
+      }
+    }
+  });
+
+  return { procesados: datosPorMes.size, agregados, actualizados };
 };

--- a/src/pages/indices/IndicesPage.tsx
+++ b/src/pages/indices/IndicesPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
@@ -6,37 +6,204 @@ import { budgetDB, IndiceIPC } from '@/db/dexie';
 import EmptyState from '@/components/ui/EmptyState';
 import { actualizarIndicesDesdeAPI } from '@/lib/ipc';
 
-const schema = z.object({
+type TipoIndice = 'IPC' | 'UTM';
+
+const schemaIPC = z.object({
   mes: z.string(),
   valor: z.number().positive(),
   esUltimo: z.boolean().optional()
 });
 
+const schemaUTM = z.object({
+  mes: z.string(),
+  utm: z.number().positive()
+});
+
+const parseNumericInput = (value: string): number | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const normalized = trimmed.replace(/,/g, '.');
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const describirCantidad = (cantidad: number, singular: string, plural: string) => {
+  return `${cantidad} ${cantidad === 1 ? singular : plural}`;
+};
+
+const obtenerUltimoMesConDato = (lista: IndiceIPC[] | undefined, tipo: 'valor' | 'utm') => {
+  if (!lista || lista.length === 0) return null;
+  return lista
+    .filter((indice) => indice[tipo] !== undefined)
+    .reduce<string | null>((max, indice) => {
+      if (!max || indice.mes > max) {
+        return indice.mes;
+      }
+      return max;
+    }, null);
+};
+
 const IndicesPage = () => {
   const indices = useLiveQuery(() => budgetDB.indices.orderBy('mes').reverse().toArray(), []);
-  const [form, setForm] = useState({ mes: new Date().toISOString().slice(0, 7), valor: 100, esUltimo: false });
+  const [tipoSeleccionado, setTipoSeleccionado] = useState<TipoIndice>('IPC');
+  const [formIPC, setFormIPC] = useState<{ mes: string; valor: string; esUltimo: boolean }>(() => ({
+    mes: new Date().toISOString().slice(0, 7),
+    valor: '',
+    esUltimo: false
+  }));
+  const [formUTM, setFormUTM] = useState<{ mes: string; utm: string }>(() => ({
+    mes: new Date().toISOString().slice(0, 7),
+    utm: ''
+  }));
   const [mensaje, setMensaje] = useState<string | null>(null);
+  const [cargandoAPI, setCargandoAPI] = useState(false);
+  const [autoSyncIntentado, setAutoSyncIntentado] = useState(false);
+
+  const actualizarDesdeAPI = useCallback(async () => {
+    setCargandoAPI(true);
+    setMensaje('Consultando API…');
+    try {
+      const resultado = await actualizarIndicesDesdeAPI();
+      if (resultado.procesados === 0) {
+        setMensaje('La API no entregó datos recientes. Intenta nuevamente más tarde.');
+        return;
+      }
+
+      const partes: string[] = [];
+      if (resultado.agregados > 0) {
+        partes.push(describirCantidad(resultado.agregados, 'mes nuevo', 'meses nuevos'));
+      }
+      if (resultado.actualizados > 0) {
+        partes.push(describirCantidad(resultado.actualizados, 'mes ajustado', 'meses ajustados'));
+      }
+      if (partes.length === 0) {
+        setMensaje('Los valores de IPC y UTM ya estaban actualizados.');
+        return;
+      }
+      setMensaje(`Se sincronizaron ${partes.join(' y ')} desde la CMF.`);
+    } catch (error) {
+      const descripcion = error instanceof Error ? error.message : 'Error desconocido al consultar la API.';
+      setMensaje(descripcion);
+    } finally {
+      setCargandoAPI(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!indices) return;
+    const indice = indices.find((item) => item.mes === formIPC.mes);
+    setFormIPC((prev) => ({
+      ...prev,
+      valor: indice?.valor !== undefined ? String(indice.valor) : '',
+      esUltimo: indice?.esUltimo ?? false
+    }));
+    setFormUTM((prev) => ({
+      ...prev,
+      utm: indice?.utm !== undefined ? String(indice.utm) : ''
+    }));
+  }, [indices, formIPC.mes]);
+
+  useEffect(() => {
+    if (!indices || autoSyncIntentado) return;
+
+    const mesActual = new Date().toISOString().slice(0, 7);
+    const ultimoMesIPC = obtenerUltimoMesConDato(indices, 'valor');
+    const ultimoMesUTM = obtenerUltimoMesConDato(indices, 'utm');
+
+    const ipcActualizado = ultimoMesIPC ? ultimoMesIPC >= mesActual : false;
+    const utmActualizada = ultimoMesUTM ? ultimoMesUTM >= mesActual : false;
+
+    setAutoSyncIntentado(true);
+
+    if (ipcActualizado && utmActualizada) {
+      return;
+    }
+
+    actualizarDesdeAPI().catch((error) => {
+      console.error('Error al actualizar índices automáticamente', error);
+    });
+  }, [indices, autoSyncIntentado, actualizarDesdeAPI]);
+
+  const indicesPorTipo = useMemo(() => {
+    if (!indices) return [];
+    if (tipoSeleccionado === 'IPC') {
+      return indices.filter((indice) => indice.valor !== undefined);
+    }
+    return indices.filter((indice) => indice.utm !== undefined);
+  }, [indices, tipoSeleccionado]);
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
-    const parsed = schema.safeParse({ ...form, valor: Number(form.valor) });
-    if (!parsed.success) {
-      setMensaje('Verifica mes y valor.');
+    if (tipoSeleccionado === 'IPC') {
+      const valor = parseNumericInput(formIPC.valor);
+      const parsed = schemaIPC.safeParse({
+        mes: formIPC.mes,
+        valor: valor ?? Number.NaN,
+        esUltimo: formIPC.esUltimo
+      });
+      if (!parsed.success) {
+        setMensaje('Verifica mes y valor del IPC.');
+        return;
+      }
+
+      try {
+        await budgetDB.transaction('rw', budgetDB.indices, async () => {
+          const existente = await budgetDB.indices.get({ mes: parsed.data.mes });
+          let objetivoId: string;
+
+          if (existente) {
+            await budgetDB.indices.update(existente.id, {
+              valor: parsed.data.valor,
+              esUltimo: parsed.data.esUltimo
+            });
+            objetivoId = existente.id;
+          } else {
+            const nuevo: IndiceIPC = {
+              id: uuid(),
+              mes: parsed.data.mes,
+              valor: parsed.data.valor,
+              esUltimo: parsed.data.esUltimo
+            };
+            await budgetDB.indices.add(nuevo);
+            objetivoId = nuevo.id;
+          }
+
+          if (parsed.data.esUltimo) {
+            await budgetDB.indices
+              .filter((item) => item.id !== objetivoId && item.esUltimo)
+              .modify({ esUltimo: false });
+          }
+        });
+        setMensaje('Índice IPC guardado.');
+      } catch (error) {
+        const descripcion = error instanceof Error ? error.message : 'Error desconocido al guardar el IPC.';
+        setMensaje(descripcion);
+      }
       return;
     }
-    const indice: IndiceIPC = {
-      id: uuid(),
-      mes: parsed.data.mes,
-      valor: parsed.data.valor,
-      esUltimo: parsed.data.esUltimo
-    };
-    await budgetDB.indices.add(indice);
-    if (indice.esUltimo) {
-      await budgetDB.indices
-        .filter((item) => item.id !== indice.id && item.esUltimo)
-        .modify({ esUltimo: false });
+
+    const utm = parseNumericInput(formUTM.utm);
+    const parsed = schemaUTM.safeParse({
+      mes: formUTM.mes,
+      utm: utm ?? Number.NaN
+    });
+    if (!parsed.success) {
+      setMensaje('Verifica mes y valor de la UTM.');
+      return;
     }
-    setMensaje('Índice guardado.');
+
+    try {
+      const existente = await budgetDB.indices.get({ mes: parsed.data.mes });
+      if (!existente) {
+        setMensaje('Primero registra el índice IPC de ese mes antes de guardar la UTM.');
+        return;
+      }
+      await budgetDB.indices.update(existente.id, { utm: parsed.data.utm });
+      setMensaje('Valor UTM guardado.');
+    } catch (error) {
+      const descripcion = error instanceof Error ? error.message : 'Error desconocido al guardar la UTM.';
+      setMensaje(descripcion);
+    }
   };
 
   const hayDuplicadosUltimo = useMemo(() => {
@@ -44,59 +211,98 @@ const IndicesPage = () => {
     return indices.filter((indice) => indice.esUltimo).length > 1;
   }, [indices]);
 
-  const actualizarDesdeAPI = async () => {
-    setMensaje('Consultando API…');
-    const nuevos = await actualizarIndicesDesdeAPI();
-    // TODO: reemplazar con carga real desde API externa.
-    if (nuevos.length === 0) {
-      setMensaje('API aún no configurada. Usa carga manual.');
-    }
+  const cambiarTipo = (tipo: TipoIndice) => {
+    setTipoSeleccionado(tipo);
+    setMensaje(null);
+  };
+
+  const sincronizarMes = (nuevoMes: string) => {
+    setFormIPC((prev) => ({ ...prev, mes: nuevoMes }));
+    setFormUTM((prev) => ({ ...prev, mes: nuevoMes }));
   };
 
   return (
     <section className="space-y-6">
+      <div className="flex flex-col gap-2 rounded-3xl border border-slate-900 bg-slate-900/70 p-3 shadow-soft sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-lg font-semibold text-slate-100">Índices</h2>
+        <div className="flex rounded-full bg-slate-900/80 p-1">
+          {(['IPC', 'UTM'] as const).map((tipo) => {
+            const activo = tipoSeleccionado === tipo;
+            return (
+              <button
+                key={tipo}
+                type="button"
+                onClick={() => cambiarTipo(tipo)}
+                className={`rounded-full px-3 py-1 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand ${
+                  activo ? 'bg-brand text-white shadow-soft' : 'text-slate-300 hover:text-white'
+                }`}
+                aria-pressed={activo}
+              >
+                {tipo}
+              </button>
+            );
+          })}
+        </div>
+      </div>
       <form onSubmit={onSubmit} className="grid gap-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
-        <h2 className="text-lg font-semibold text-slate-100">Agregar índice IPC</h2>
+        <h3 className="text-lg font-semibold text-slate-100">
+          {tipoSeleccionado === 'IPC' ? 'Agregar índice IPC' : 'Registrar valor UTM'}
+        </h3>
         <label className="text-sm">
           Mes
           <input
             type="month"
-            value={form.mes}
-            onChange={(event) => setForm((prev) => ({ ...prev, mes: event.target.value }))}
+            value={tipoSeleccionado === 'IPC' ? formIPC.mes : formUTM.mes}
+            onChange={(event) => sincronizarMes(event.target.value)}
             className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </label>
-        <label className="text-sm">
-          Valor
-          <input
-            inputMode="decimal"
-            value={form.valor}
-            onChange={(event) => setForm((prev) => ({ ...prev, valor: Number(event.target.value) }))}
-            className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
-          />
-        </label>
-        <label className="flex items-center gap-2 text-sm text-slate-300">
-          <input
-            type="checkbox"
-            checked={form.esUltimo}
-            onChange={(event) => setForm((prev) => ({ ...prev, esUltimo: event.target.checked }))}
-            className="h-4 w-4 rounded border-slate-700 bg-slate-900"
-          />
-          Marcar como último índice publicado
-        </label>
+        {tipoSeleccionado === 'IPC' ? (
+          <>
+            <label className="text-sm">
+              Valor IPC
+              <input
+                inputMode="decimal"
+                value={formIPC.valor}
+                onChange={(event) => setFormIPC((prev) => ({ ...prev, valor: event.target.value }))}
+                className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={formIPC.esUltimo}
+                onChange={(event) => setFormIPC((prev) => ({ ...prev, esUltimo: event.target.checked }))}
+                className="h-4 w-4 rounded border-slate-700 bg-slate-900"
+              />
+              Marcar como último índice publicado
+            </label>
+          </>
+        ) : (
+          <label className="text-sm">
+            Valor UTM
+            <input
+              inputMode="decimal"
+              value={formUTM.utm}
+              onChange={(event) => setFormUTM((prev) => ({ ...prev, utm: event.target.value }))}
+              className="mt-1 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </label>
+        )}
         <div className="flex flex-wrap gap-2">
           <button
             type="submit"
             className="rounded-full bg-brand px-4 py-2 text-sm font-medium text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
-            Guardar índice
+            {tipoSeleccionado === 'IPC' ? 'Guardar índice IPC' : 'Guardar UTM'}
           </button>
           <button
             type="button"
             onClick={actualizarDesdeAPI}
-            className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand"
+            disabled={cargandoAPI}
+            className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Actualizar desde API
+            {cargandoAPI ? 'Actualizando…' : 'Actualizar desde API'}
           </button>
         </div>
         {mensaje && (
@@ -104,24 +310,50 @@ const IndicesPage = () => {
             {mensaje}
           </p>
         )}
-        {hayDuplicadosUltimo && (
+        {hayDuplicadosUltimo && tipoSeleccionado === 'IPC' && (
           <p className="text-xs text-orange-400">Hay más de un índice marcado como último.</p>
         )}
       </form>
 
       <section className="space-y-3 rounded-3xl border border-slate-900 bg-slate-900/70 p-4 shadow-soft">
-        <h2 className="text-sm font-semibold text-slate-200">Historial de índices</h2>
-        {!indices || indices.length === 0 ? (
-          <EmptyState icon="📈" title="Sin datos" description="Agrega los índices IPC de tu fuente preferida." />
+        <h3 className="text-sm font-semibold text-slate-200">
+          {tipoSeleccionado === 'IPC' ? 'Historial IPC' : 'Historial UTM'}
+        </h3>
+        {!indices || indicesPorTipo.length === 0 ? (
+          <EmptyState
+            icon="📈"
+            title="Sin datos"
+            description={
+              tipoSeleccionado === 'IPC'
+                ? 'Agrega los índices IPC de tu fuente preferida.'
+                : 'Agrega los valores UTM manualmente o desde la API.'
+            }
+          />
         ) : (
           <ul className="space-y-2 text-sm">
-            {indices.map((indice) => (
+            {indicesPorTipo.map((indice) => (
               <li key={indice.id} className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-900/90 p-3">
                 <div>
                   <p className="font-semibold text-slate-100">{indice.mes}</p>
-                  <p className="text-xs text-slate-400">Valor {indice.valor}</p>
+                  {tipoSeleccionado === 'IPC' ? (
+                    <>
+                      <p className="text-xs text-slate-400">Valor IPC {indice.valor}</p>
+                      {indice.utm !== undefined && (
+                        <p className="text-xs text-slate-400">Valor UTM {indice.utm}</p>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-xs text-slate-400">Valor UTM {indice.utm}</p>
+                      {indice.valor !== undefined && (
+                        <p className="text-xs text-slate-400">Valor IPC {indice.valor}</p>
+                      )}
+                    </>
+                  )}
                 </div>
-                {indice.esUltimo && <span className="text-xs text-emerald-300">Último publicado</span>}
+                {indice.esUltimo && tipoSeleccionado === 'IPC' && (
+                  <span className="text-xs text-emerald-300">Último publicado</span>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- generate IPC/UTM seed values dynamically for the latest 12 months so demo data matches the current date
- auto-trigger CMF synchronization on the Índices page when stored IPC or UTM data is stale, reusing improved sync messaging

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e33869da90832e8365e913212868de